### PR TITLE
Improve ssh analytics

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,11 +69,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	}));
 
-	// For analitycs, will be called by gitpod-remote extension
-	context.subscriptions.push(vscode.commands.registerCommand('__gitpod.getLocalMachineId', () => {
-		return vscode.env.machineId;
-	}));
-
 	const authProvider = new GitpodAuthenticationProvider(context, logger, telemetry);
 	const remoteConnector = new RemoteConnector(context, logger, telemetry);
 	context.subscriptions.push(authProvider);
@@ -88,6 +83,10 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 		}
 	}));
+
+	if (await remoteConnector.checkRemoteConnectionSuccessful()) {
+		context.subscriptions.push(vscode.commands.registerCommand('gitpod.api.autoTunnel', remoteConnector.autoTunnelCommand, remoteConnector));
+	}
 
 	if (!context.globalState.get<boolean>(FIRST_INSTALL_KEY, false)) {
 		await context.globalState.update(FIRST_INSTALL_KEY, true);

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -726,7 +726,7 @@ export default class RemoteConnector extends Disposable {
 
 		await this.updateRemoteSSHConfig(usingSSHGateway, localAppSSHConfigPath);
 
-		await this.context.globalState.update(`ssh-remote+${sshDestination}`, { ...params, usingSSHGateway });
+		await this.context.globalState.update(sshDestination!, { ...params, usingSSHGateway });
 
 		vscode.commands.executeCommand(
 			'vscode.openFolder',
@@ -780,7 +780,7 @@ export default class RemoteConnector extends Disposable {
 			const host = new URL(gitpodHost).host;
 			const connectionSuccessful = sshDest.hostName.endsWith(host) && await isRemoteExtensionHostRunning();
 
-			const connectionInfo = this.context.globalState.get<SSHConnectionParams & { usingSSHGateway: boolean }>(remoteUri.authority);
+			const connectionInfo = this.context.globalState.get<SSHConnectionParams & { usingSSHGateway: boolean }>(sshDestStr);
 			if (connectionInfo) {
 				const kind = connectionInfo.usingSSHGateway ? 'gateway' : 'local-app';
 				if (connectionSuccessful) {


### PR DESCRIPTION
How to test for failure:
- SSH gateway:
  - To force the connection to fail we can remove all our ssh keys so you'll be required to use password authentication and then just type an incorrect password
- Local app:
  - ....