### PR TITLE
Fix auth validation

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -144,6 +144,7 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 				if (e.message === 'Unexpected server response: 401') {
 					return undefined;
 				}
+				this._logger.error(`Error while verifying session with the following scopes: ${scopesStr}`, e);
 			}
 
 			this._logger.trace(`Read the following session from the keychain with the following scopes: ${scopesStr}`);

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -136,15 +136,13 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 			const scopesStr = sortedScopes.join(' ');
 
 			let userInfo: { id: string; accountName: string } | undefined;
-			if (!session.account) {
-				try {
-					userInfo = await this._gitpodServer.getUserInfo(session.accessToken);
-					this._logger.info(`Verified session with the following scopes: ${scopesStr}`);
-				} catch (e) {
-					// Remove sessions that return unauthorized response
-					if (e.message === 'Unauthorized') {
-						return undefined;
-					}
+			try {
+				userInfo = await this._gitpodServer.getUserInfo(session.accessToken);
+				this._logger.info(`Verified session with the following scopes: ${scopesStr}`);
+			} catch (e) {
+				// Remove sessions that return unauthorized response
+				if (e.message === 'Unexpected server response: 401') {
+					return undefined;
 				}
 			}
 

--- a/src/internalApi.ts
+++ b/src/internalApi.ts
@@ -6,7 +6,7 @@
 import { GitpodClient, GitpodServer, GitpodServiceImpl } from '@gitpod/gitpod-protocol/lib/gitpod-service';
 import { JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy-factory';
 import { listen as doListen } from 'vscode-ws-jsonrpc';
-import WebSocket from 'ws';
+import WebSocket, { ErrorEvent } from 'ws';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import * as vscode from 'vscode';
 import Log from './common/logger';
@@ -22,9 +22,9 @@ export const unauthorizedErr = 'unauthorized';
 class GitpodServerApi extends vscode.Disposable {
 
 	readonly service: GitpodConnection;
-	private readonly webSocket: any;
-	private readonly onWillCloseEmitter = new vscode.EventEmitter<number | undefined>();
-	readonly onWillClose = this.onWillCloseEmitter.event;
+	private readonly webSocket: ReconnectingWebSocket;
+	private readonly onErrorEmitter = new vscode.EventEmitter<Error>();
+	readonly onError = this.onErrorEmitter.event;
 
 	constructor(accessToken: string, serviceUrl: string, private readonly logger: Log) {
 		super(() => this.internalDispose());
@@ -34,14 +34,12 @@ class GitpodServerApi extends vscode.Disposable {
 		const factory = new JsonRpcProxyFactory<GitpodServer>();
 		this.service = new GitpodServiceImpl<GitpodClient, GitpodServer>(factory.createProxy());
 
-		let retry = 1;
-		const maxRetries = 3;
 		const webSocket = new ReconnectingWebSocket(`${serviceUrl.replace('https', 'wss')}/api/v1`, undefined, {
 			maxReconnectionDelay: 10000,
 			minReconnectionDelay: 1000,
 			reconnectionDelayGrowFactor: 1.5,
 			connectionTimeout: 10000,
-			maxRetries: Infinity,
+			maxRetries: 3,
 			debug: false,
 			startClosed: false,
 			WebSocket: class extends WebSocket {
@@ -54,19 +52,10 @@ class GitpodServerApi extends vscode.Disposable {
 							'X-Client-Version': vscode.version
 						}
 					});
-					this.on('unexpected-response', (_, resp) => {
-						this.terminate();
-
-						// if mal-formed handshake request (unauthorized, forbidden) or client actions (redirect) are required then fail immediately
-						// otherwise try several times and fail, maybe temporarily unavailable, like server restart
-						if (retry++ >= maxRetries || (typeof resp.statusCode === 'number' && 300 <= resp.statusCode && resp.statusCode < 500)) {
-							webSocket.close(resp.statusCode);
-						}
-					});
 				}
 			}
 		});
-		webSocket.onerror = (e: any) => logger.error('internal server api: failed to open socket', e);
+		webSocket.onerror = (e: ErrorEvent) => this.onErrorEmitter.fire(e.error);
 
 		doListen({
 			webSocket: (webSocket as any),
@@ -76,18 +65,9 @@ class GitpodServerApi extends vscode.Disposable {
 		this.webSocket = webSocket;
 	}
 
-	private close(statusCode?: number): void {
-		this.onWillCloseEmitter.fire(statusCode);
-		try {
-			this.webSocket.close();
-		} catch (e) {
-			this.logger.error('internal server api: failed to close socket', e);
-		}
-	}
-
 	internalDispose() {
-		this.close();
-		this.onWillCloseEmitter.dispose();
+		this.webSocket.close();
+		this.onErrorEmitter.dispose();
 	}
 }
 
@@ -95,12 +75,8 @@ export function withServerApi<T>(accessToken: string, serviceUrl: string, cb: (s
 	const api = new GitpodServerApi(accessToken, serviceUrl, logger);
 	return Promise.race([
 		cb(api.service),
-		new Promise<T>((_, reject) => api.onWillClose(statusCode => {
-			if (statusCode === 401) {
-				reject(new Error(unauthorizedErr));
-			} else {
-				reject(new Error('closed'));
-			}
+		new Promise<T>((_, reject) => api.onError(error => {
+			reject(error);
 		}))
 	]).finally(() => api.dispose());
 }


### PR DESCRIPTION
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11296

## How to test
<!-- Provide steps to test this PR -->
1. [Run this extension](https://github.com/gitpod-io/gitpod-vscode-desktop/blob/master/docs/CONTRIBUTING.md)
2. Connect to a workspace in any prev env (use SSH gateway) you can use this one https://jp-heartbeat-test.preview.gitpod-dev.com/workspaces
3. After successful connection, delete the gitpod token from database, or you can rebuild the prev env with `with-clean-slate-deployment` so DB gets recreated
4. Try to connect again to a workspace it should ask to login again and not fail silently as before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
