### PR TITLE
Make release notes shown after vscode startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"onCommand:gitpod.api.autoTunnel",
 		"onCommand:gitpod.showReleaseNotes",
 		"onAuthenticationRequest:gitpod",
-		"onUri"
+		"onUri",
+		"onStartupFinished"
 	],
 	"contributes": {
 		"authentication": [

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -113,10 +113,10 @@ class ReleaseNotesPanel {
 		if (!info) {
 			return content;
 		}
-
+		const releaseDate = Intl.DateTimeFormat('en-US', { dateStyle: 'long' }).format(new Date(releaseId));
 		return [
 			`# ${info.title}`,
-			`> Published at ${releaseId}, see also https://gitpod.io/changelog`,
+			`> Published on ${releaseDate}, see also https://www.gitpod.io/changelog`,
 			`![${info.alt ?? 'image'}](https://www.gitpod.io/images/changelog/${info.image})`,
 			content,
 		].join('\n\n');


### PR DESCRIPTION
Align to @filiptronicek 's comments https://github.com/gitpod-io/openvscode-server/pull/381#discussion_r925983137

Make release notes shown after vscode startup
