### PR TITLE
Add telemetry event for ssh modal

### DIFF
--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -618,7 +618,7 @@ export default class RemoteConnector extends Disposable {
 		return true;
 	}
 
-	private async showSSHPasswordModal(password: string, gitpodHost: string) {
+	private async showSSHPasswordModal(password: string, gitpodHost: string, sshParams: SSHConnectionParams) {
 		const maskedPassword = '•'.repeat(password.length - 3) + password.substring(password.length - 3);
 
 		const gitpodVersion = await getGitpodVersion(gitpodHost);
@@ -631,6 +631,7 @@ export default class RemoteConnector extends Disposable {
 			? `You don't have registered any SSH public key for this machine in your Gitpod account.\nAlternatively, copy and use this temporary password until workspace restart: ${maskedPassword}`
 			: `An SSH key is required for passwordless authentication.\nAlternatively, copy and use this password: ${maskedPassword}`;
 		const action = await vscode.window.showWarningMessage(message, { modal: true }, copy, configureSSH, showLogs);
+        this.telemetry.sendRawTelemetryEvent('vscode_desktop_ssh_gateway_modal', { action: action?.title ?? 'Cancelled', ...sshParams, gitpodVersion: gitpodVersion.raw });
 		if (action === copy) {
 			await vscode.env.clipboard.writeText(password);
 			return;
@@ -707,7 +708,7 @@ export default class RemoteConnector extends Disposable {
 				sshDestination = destination;
 
 				if (password) {
-					await this.showSSHPasswordModal(password, params.gitpodHost);
+					await this.showSSHPasswordModal(password, params.gitpodHost, params);
 				}
 
 				this.telemetry.sendRawTelemetryEvent('vscode_desktop_ssh', { kind: 'gateway', status: 'connected', ...params, gitpodVersion: gitpodVersion.raw });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Same as title, to see how many users go with copy password (no SSH public key uploaded yet)

See also [internal chat](https://gitpod.slack.com/archives/C01KGM9BH54/p1658826643857369?thread_ts=1658825096.949629&cid=C01KGM9BH54)

## TODO
- [ ] Add [tracking plan](https://www.notion.so/gitpod/d1c05025dae64f4e8dcd3188f121e270?v=e7e87f95dcac436f86d4ec2698e795a7) in notion

## How to test
<!-- Provide steps to test this PR -->
No need
