### PR TITLE
Get ssh identity file from ssh config and ssh agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
 		"node-fetch": "2.6.7",
 		"pkce-challenge": "^3.0.0",
 		"semver": "^7.3.7",
+		"ssh-config": "^4.1.6",
 		"ssh2": "^1.10.0",
 		"tmp": "^0.2.1",
 		"uuid": "8.1.0",

--- a/src/common/files.ts
+++ b/src/common/files.ts
@@ -5,7 +5,6 @@
 
 import * as fs from 'fs';
 import * as os from 'os';
-import * as path from 'path';
 
 const homeDir = os.homedir();
 
@@ -20,18 +19,4 @@ export async function exists(path: string) {
 
 export function untildify(path: string){
 	return path.replace(/^~(?=$|\/|\\)/, homeDir);
-}
-
-export function resolveHomeDir(filepath: string | undefined) {
-    if (!filepath) {
-        return filepath;
-    }
-    const homedir = os.homedir();
-    if (filepath === '~') {
-        return homedir;
-    }
-    if (filepath.startsWith('~/')) {
-        return path.join(homedir, filepath.slice(2));
-    }
-    return filepath;
 }

--- a/src/common/files.ts
+++ b/src/common/files.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 
 const homeDir = os.homedir();
 
@@ -19,4 +20,18 @@ export async function exists(path: string) {
 
 export function untildify(path: string){
 	return path.replace(/^~(?=$|\/|\\)/, homeDir);
+}
+
+export function resolveHomeDir(filepath: string | undefined) {
+    if (!filepath) {
+        return filepath;
+    }
+    const homedir = os.homedir();
+    if (filepath === '~') {
+        return homedir;
+    }
+    if (filepath.startsWith('~/')) {
+        return path.join(homedir, filepath.slice(2));
+    }
+    return filepath;
 }

--- a/src/common/files.ts
+++ b/src/common/files.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
+import * as os from 'os';
+
+const homeDir = os.homedir();
 
 export async function exists(path: string) {
     try {
@@ -12,4 +15,8 @@ export async function exists(path: string) {
     } catch {
         return false;
     }
+}
+
+export function untildify(path: string){
+	return path.replace(/^~(?=$|\/|\\)/, homeDir);
 }

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitpod. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const isWindows = process.platform === 'win32';
+export const isMacintosh = process.platform === 'darwin';
+export const isLinux = process.platform === 'linux';

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -464,7 +464,7 @@ export default class RemoteConnector extends Disposable {
 
 		let sshAgentParsedKeys: ParsedKey[] = [];
 		try {
-			let sshAgentSock = isWindows ? `\\.\pipe\openssh-ssh-agent` : (hostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK']);
+			let sshAgentSock = isWindows ? '\\\\.\\pipe\\openssh-ssh-agent' : (hostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK']);
 			if (!sshAgentSock) {
 				throw new Error(`SSH_AUTH_SOCK environment variable not defined`);
 			}

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -28,7 +28,7 @@ import { HeartbeatManager } from './heartbeat';
 import { getGitpodVersion, isFeatureSupported } from './featureSupport';
 import SSHConfiguration from './ssh/sshConfig';
 import { isWindows } from './common/platform';
-import { untildify } from './common/files';
+import { resolveHomeDir, untildify } from './common/files';
 
 interface SSHConnectionParams {
 	workspaceId: string;
@@ -440,7 +440,7 @@ export default class RemoteConnector extends Disposable {
 			identityFiles.push(...DEFAULT_IDENTITY_FILES);
 		}
 
-		const identityFileContentsResult = await Promise.allSettled(identityFiles.map(async path => fs.promises.readFile(path + '.pub')));
+		const identityFileContentsResult = await Promise.allSettled(identityFiles.map(async path => fs.promises.readFile(resolveHomeDir(path) + '.pub')));
 		const fileKeys = identityFileContentsResult.map((result, i) => {
 			if (result.status === 'rejected') {
 				return undefined;
@@ -462,14 +462,20 @@ export default class RemoteConnector extends Disposable {
 			};
 		}).filter(<T>(v: T | undefined): v is T => !!v);
 
-		const sshAgentSock = isWindows ? `\\.\pipe\openssh-ssh-agent` : (hostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK']);
+		let sshAgentSock: string | undefined;
+		if (isWindows) {
+			sshAgentSock = `\\.\pipe\openssh-ssh-agent`;
+		} else {
+			sshAgentSock = (hostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK']);
+			sshAgentSock = resolveHomeDir(sshAgentSock);
+		}
 		let sshAgentParsedKeys: ParsedKey[] = [];
 		try {
-			if (!sshAgentSock) {
-				throw new Error(`SSH_AUTH_SOCK environment variable not defined`);
-			}
-
 			sshAgentParsedKeys = await new Promise<ParsedKey[]>((resolve, reject) => {
+				if (!sshAgentSock) {
+					reject(new Error(`SSH_AUTH_SOCK environment variable not defined`));
+					return;
+				}
 				const sshAgent = new OpenSSHAgent(sshAgentSock);
 				sshAgent.getIdentities((err, publicKeys) => {
 					if (err) {

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -13,7 +13,8 @@ import * as http from 'http';
 import * as net from 'net';
 import * as crypto from 'crypto';
 import fetch, { Response } from 'node-fetch';
-import { Client as sshClient, utils as sshUtils } from 'ssh2';
+import { Client as sshClient, OpenSSHAgent, utils as sshUtils } from 'ssh2';
+import { ParsedKey } from 'ssh2-streams';
 import * as tmp from 'tmp';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -22,10 +23,12 @@ import { Disposable } from './common/dispose';
 import { withServerApi } from './internalApi';
 import TelemetryReporter from './telemetryReporter';
 import { addHostToHostFile, checkNewHostInHostkeys } from './ssh/hostfile';
-import { checkDefaultIdentityFiles } from './ssh/identityFiles';
+import { DEFAULT_IDENTITY_FILES } from './ssh/identityFiles';
 import { HeartbeatManager } from './heartbeat';
 import { getGitpodVersion, isFeatureSupported } from './featureSupport';
 import SSHConfiguration from './ssh/sshConfig';
+import { isWindows } from './common/platform';
+import { untildify } from './common/files';
 
 interface SSHConnectionParams {
 	workspaceId: string;
@@ -430,14 +433,83 @@ export default class RemoteConnector extends Disposable {
 		}
 	}
 
-	private async getIdentityFilePaths(gitpodHost: string) {
-		const list = await checkDefaultIdentityFiles();
-		const sshConfiguration = await SSHConfiguration.loadFromFS();
-		const hostConfiguration = sshConfiguration.getHostConfiguration(new URL(gitpodHost).host);
-		if (!!hostConfiguration.IdentityFile) {
-			list.unshift(hostConfiguration.IdentityFile);
+	// From https://github.com/openssh/openssh-portable/blob/acb2059febaddd71ee06c2ebf63dcf211d9ab9f2/sshconnect2.c#L1689-L1690
+	private async getIdentityKeys(hostConfig: Record<string, string>) {
+		const identityFiles: string[] = ((hostConfig['IdentityFile'] as unknown as string[]) || []).map(untildify);
+		if (identityFiles.length === 0) {
+			identityFiles.push(...DEFAULT_IDENTITY_FILES);
 		}
-		return list;
+
+		const identityFileContentsResult = await Promise.allSettled(identityFiles.map(async path => fs.promises.readFile(path + '.pub')));
+		const fileKeys = identityFileContentsResult.map((result, i) => {
+			if (result.status === 'rejected') {
+				return undefined;
+			}
+
+			const parsedResult = sshUtils.parseKey(result.value);
+			if (parsedResult instanceof Error || !parsedResult) {
+				this.logger.error(`Error while parsing SSH public key ${identityFiles[i] + '.pub'}:`, parsedResult);
+				return undefined;
+			}
+
+			const parsedKey = Array.isArray(parsedResult) ? parsedResult[0] : parsedResult;
+			const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
+
+			return {
+				filename: identityFiles[i],
+				parsedKey,
+				fingerprint
+			};
+		}).filter(<T>(v: T | undefined): v is T => !!v);
+
+		const sshAgentSock = isWindows ? `\\.\pipe\openssh-ssh-agent` : (hostConfig['IdentityAgent'] || process.env['SSH_AUTH_SOCK']);
+		let sshAgentParsedKeys: ParsedKey[] = [];
+		try {
+			if (!sshAgentSock) {
+				throw new Error(`SSH_AUTH_SOCK environment variable not defined`);
+			}
+
+			sshAgentParsedKeys = await new Promise<ParsedKey[]>((resolve, reject) => {
+				const sshAgent = new OpenSSHAgent(sshAgentSock);
+				sshAgent.getIdentities((err, publicKeys) => {
+					if (err) {
+						reject(err);
+					} else {
+						resolve(publicKeys || []);
+					}
+				});
+			});
+		} catch (e) {
+			this.logger.error(`Couldn't get identities from OpenSSH agent`, e);
+		}
+
+		const sshAgentKeys = sshAgentParsedKeys.map(parsedKey => {
+			const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
+			return {
+				filename: parsedKey.comment,
+				parsedKey,
+				fingerprint
+			};
+		});
+
+		const identitiesOnly = (hostConfig['IdentitiesOnly'] || '').toLowerCase() === 'yes';
+		const agentKeys: { filename: string; parsedKey: ParsedKey; fingerprint: string }[] = [];
+		const preferredIdentityKeys: { filename: string; parsedKey: ParsedKey; fingerprint: string }[] = [];
+		for (const agentKey of sshAgentKeys) {
+			const foundIdx = fileKeys.findIndex(k => agentKey.parsedKey.type === k.parsedKey.type && agentKey.fingerprint === k.fingerprint);
+			if (foundIdx >= 0) {
+				preferredIdentityKeys.push(fileKeys[foundIdx]);
+				fileKeys.splice(foundIdx, 1);
+			} else if (!identitiesOnly) {
+				agentKeys.push(agentKey);
+			}
+		}
+		preferredIdentityKeys.push(...agentKeys);
+		preferredIdentityKeys.push(...fileKeys);
+
+		this.logger.trace(`Identity keys:`, preferredIdentityKeys.length ? preferredIdentityKeys.map(k => `${k.filename} ${k.parsedKey.type} SHA256:${k.fingerprint}`).join('\n') : 'None');
+
+		return preferredIdentityKeys;
 	}
 
 	private async getWorkspaceSSHDestination(accessToken: string, { workspaceId, gitpodHost }: SSHConnectionParams): Promise<{ destination: string; password?: string }> {
@@ -515,31 +587,16 @@ export default class RemoteConnector extends Disposable {
 			this.logger.error(`Couldn't write '${sshDestInfo.hostName}' host to known_hosts file:`, e);
 		}
 
-		let identityFilePaths = await this.getIdentityFilePaths(gitpodHost);
-		this.logger.trace(`Default identity files:`, identityFilePaths.length ? identityFilePaths.toString() : 'None');
+		const sshConfiguration = await SSHConfiguration.loadFromFS();
+		const hostConfiguration = sshConfiguration.getHostConfiguration(sshDestInfo.hostName);
+
+		let identityKeys = await this.getIdentityKeys(hostConfiguration);
 
 		if (registeredSSHKeys) {
-			const keyFingerprints = registeredSSHKeys.map(i => i.fingerprint);
-			const publickKeyFiles = await Promise.allSettled(identityFilePaths.map(path => fs.promises.readFile(path + '.pub')));
-			identityFilePaths = identityFilePaths.filter((_, index) => {
-				const result = publickKeyFiles[index];
-				if (result.status === 'rejected') {
-					return false;
-				}
-
-				const parsedResult = sshUtils.parseKey(result.value);
-				if (parsedResult instanceof Error || !parsedResult) {
-					this.logger.error(`Error while parsing SSH public key${identityFilePaths[index] + '.pub'}:`, parsedResult);
-					return false;
-				}
-
-				const parsedKey = Array.isArray(parsedResult) ? parsedResult[0] : parsedResult;
-				const fingerprint = crypto.createHash('sha256').update(parsedKey.getPublicSSH()).digest('base64');
-				return keyFingerprints.includes(fingerprint);
-			});
-			this.logger.trace(`Registered public keys in Gitpod account:`, identityFilePaths.length ? identityFilePaths.toString() : 'None');
+			identityKeys = identityKeys.filter(k => !!registeredSSHKeys.find(regKey => regKey.fingerprint === k.fingerprint));
+			this.logger.trace(`Registered public keys in Gitpod account:`, identityKeys.length ? identityKeys.map(k => `${k.filename} ${k.parsedKey.type} SHA256:${k.fingerprint}`).join('\n') : 'None');
 		} else {
-			if (identityFilePaths.length) {
+			if (identityKeys.length) {
 				sshDestInfo.user = `${workspaceId}#${ownerToken}`;
 			}
 			this.logger.warn(`Registered SSH public keys not supported in ${gitpodHost}, using version ${gitpodVersion.version}`);
@@ -547,7 +604,7 @@ export default class RemoteConnector extends Disposable {
 
 		return {
 			destination: Buffer.from(JSON.stringify(sshDestInfo), 'utf8').toString('hex'),
-			password: identityFilePaths.length === 0 ? ownerToken : undefined
+			password: identityKeys.length === 0 ? ownerToken : undefined
 		};
 	}
 

--- a/src/ssh/identityFiles.ts
+++ b/src/ssh/identityFiles.ts
@@ -5,7 +5,6 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import { exists as fileExists } from '../common/files';
 
 const homeDir = os.homedir();
 const PATH_SSH_CLIENT_ID_DSA = path.join(homeDir, '.ssh', '/id_dsa');
@@ -16,22 +15,12 @@ const PATH_SSH_CLIENT_ID_XMSS = path.join(homeDir, '.ssh', '/id_xmss');
 const PATH_SSH_CLIENT_ID_ECDSA_SK = path.join(homeDir, '.ssh', '/id_ecdsa_sk');
 const PATH_SSH_CLIENT_ID_ED25519_SK = path.join(homeDir, '.ssh', '/id_ed25519_sk');
 
-export async function checkDefaultIdentityFiles(): Promise<string[]> {
-    const files = [
-        PATH_SSH_CLIENT_ID_DSA,
-        PATH_SSH_CLIENT_ID_ECDSA,
-        PATH_SSH_CLIENT_ID_RSA,
-        PATH_SSH_CLIENT_ID_ED25519,
-        PATH_SSH_CLIENT_ID_XMSS,
-        PATH_SSH_CLIENT_ID_ECDSA_SK,
-        PATH_SSH_CLIENT_ID_ED25519_SK
-    ];
-
-    const result: string[] = [];
-    for (const file of files) {
-        if (await fileExists(file)) {
-            result.push(file);
-        }
-    }
-    return result;
-}
+export const DEFAULT_IDENTITY_FILES: string[] = [
+    PATH_SSH_CLIENT_ID_RSA,
+    PATH_SSH_CLIENT_ID_ECDSA,
+    PATH_SSH_CLIENT_ID_ECDSA_SK,
+    PATH_SSH_CLIENT_ID_ED25519,
+    PATH_SSH_CLIENT_ID_ED25519_SK,
+    PATH_SSH_CLIENT_ID_XMSS,
+    PATH_SSH_CLIENT_ID_DSA,
+];

--- a/src/ssh/sshConfig.ts
+++ b/src/ssh/sshConfig.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitpod. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import SSHConfig, { Line, Section } from 'ssh-config';
+import * as vscode from 'vscode';
+import { exists as fileExists } from '../common/files';
+import { isWindows } from '../common/platform';
+
+const systemSSHConfig = isWindows ? path.resolve(process.env.ALLUSERSPROFILE || 'C:\\ProgramData', 'ssh\\ssh_config') : '/etc/ssh/ssh_config';
+const defaultSSHConfigPath = path.resolve(os.homedir(), '.ssh/config');
+
+export function getSSHConfigPath() {
+    const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
+    return remoteSSHconfig.get<string>('configFile') || defaultSSHConfigPath;
+}
+
+function isHostSection(line: Line): line is Section {
+    return line.type === SSHConfig.DIRECTIVE && line.param === 'Host' && !!line.value && !!(line as Section).config;
+}
+
+export default class SSHConfiguration {
+
+    static async loadFromFS(): Promise<SSHConfiguration> {
+        const sshConfigPath = getSSHConfigPath();
+        let content = '';
+        if (await fileExists(sshConfigPath)) {
+            content = await fs.promises.readFile(sshConfigPath, 'utf8');
+        }
+        const config = SSHConfig.parse(content);
+
+        if (await fileExists(systemSSHConfig)) {
+            content = await fs.promises.readFile(systemSSHConfig, 'utf8');
+            config.push(...SSHConfig.parse(content));
+        }
+
+        return new SSHConfiguration(config);
+    }
+
+    constructor(private sshConfig: SSHConfig) {
+    }
+
+    getAllConfiguredHosts(): string[] {
+        const hosts = new Set<string>();
+        this.sshConfig
+            .filter(isHostSection)
+            .forEach(hostSection => {
+                const value = Array.isArray(hostSection.value as string[] | string) ? hostSection.value[0] : hostSection.value;
+                const hasHostName = hostSection.config.find(line => line.type === SSHConfig.DIRECTIVE && line.param === 'HostName' && !!line.value);
+                const isPattern = /^!/.test(value) || /[?*]/.test(value);
+                if (hasHostName && !isPattern) {
+                    hosts.add(value);
+                }
+            });
+
+        return [...hosts.keys()];
+    }
+
+    getHostConfiguration(host: string): Record<string, string> {
+        return this.sshConfig.compute(host);
+    }
+
+    getHostNameAlias(hostname: string): string | undefined {
+        const found = this.sshConfig
+            .filter(isHostSection)
+            .find(hostSection => hostSection.config.find(line => line.type === SSHConfig.DIRECTIVE && line.param === 'HostName' && line.value === hostname));
+
+        return found?.value;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,6 +2434,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+ssh-config@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/ssh-config/-/ssh-config-4.1.6.tgz#008eee24f5e5029dc64d50de4a5a7a12342db8b1"
+  integrity sha512-YdPYn/2afoBonSFoMSvC1FraA/LKKrvy8UvbvAFGJ8gdlKuANvufLLkf8ynF2uq7Tl5+DQBIFyN37//09nAgNQ==
+
 ssh2@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.10.0.tgz#e05d870dfc8e83bc918a2ffb3dcbd4d523472dee"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Support default ssh behaviors of IdentityFile

SSH Config code is a copy of https://github.com/jeanp413/open-remote-ssh/blob/master/src/ssh/sshConfig.ts

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11467

## How to test
<!-- Provide steps to test this PR -->

- Follow this doc to run extension locally https://github.com/gitpod-io/gitpod-vscode-desktop/blob/master/docs/CONTRIBUTING.md
- Make sure debug vscode window is actived
- Create a workspace and open with desktop vscode, it should back to the debug window
- Start test with cases below

### IdentityFile
- Setup your `~/.ssh/config` (mac) with gitpod host and custom identity file
- Add an ssh key to the ssh agent with `ssh-add`
- Run extension with this branch
- Open Gitpod workspace with Desktop VSCode and connect using your debug vscode window
- See if your custom identify file works

### IdentityAgent
- Follow the [doc](https://developer.1password.com/docs/ssh/get-started#step-3-turn-on-the-1password-ssh-agent) to add and turn on 1Password ssh-agent, i.e. `id_ed25519`
```
# you can gen one by command below, which is recommend by 1password
ssh-keygen -t ed25519 -b 4096
```
- Remove related ssh key files in your computer. i.e. `id_ed25519` `id_ed25519.pub`
- Upload that ssh key to https://gitpod.io/keys and make sure only that one exists in https://gitpod.io/keys
- Run extension locally and make sure debug one is activated
- Open a new workspace with desktop VSCode
- Check if we can access without copy password modal

### Errors
Fill up incorrect `identityFile` and `identityAgent`