### PR TITLE
Initialize remote extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,12 @@
 						"description": "Use the local companion app to connect to a remote workspace.\nWarning: Connecting to a remote workspace using local companion app will be removed in the near future.",
 						"default": false,
 						"scope": "application"
+					},
+					"gitpod.remote.syncExtensions": {
+						"type": "boolean",
+						"description": "Automatically install sync extensions from Gitpod Sync Server on the remote machine.",
+						"default": true,
+						"scope": "application"
 					}
 				}
 			},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import Log from './common/logger';
 import GitpodAuthenticationProvider from './authentication';
 import RemoteConnector from './remoteConnector';
-import SettingsSync from './settingsSync';
+import { SettingsSync } from './settingsSync';
 import GitpodServer from './gitpodServer';
 import TelemetryReporter from './telemetryReporter';
 import { exportLogs } from './exportLogs';
@@ -42,10 +42,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	}));
 
-	context.subscriptions.push(new SettingsSync(logger, telemetry));
+	const settingsSync = new SettingsSync(logger, telemetry);
+	context.subscriptions.push(settingsSync);
 
 	const authProvider = new GitpodAuthenticationProvider(context, logger, telemetry);
-	remoteConnector = new RemoteConnector(context, experiments, logger, telemetry);
+	remoteConnector = new RemoteConnector(context, settingsSync, experiments, logger, telemetry);
 	context.subscriptions.push(authProvider);
 	context.subscriptions.push(vscode.window.registerUriHandler({
 		handleUri(uri: vscode.Uri) {

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -1031,7 +1031,10 @@ export default class RemoteConnector extends Disposable {
 			this.logger.warn(`Local heatbeat not supported in ${connectionInfo.gitpodHost}, using version ${gitpodVersion.version}`);
 		}
 
-		this.initializeRemoteExtensions();
+		const syncExtensions = vscode.workspace.getConfiguration('gitpod').get<boolean>('remote.syncExtensions')!;
+		if (syncExtensions) {
+			this.initializeRemoteExtensions();
+		}
 	}
 
 	public override async dispose(): Promise<void> {

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -25,11 +25,13 @@ import TelemetryReporter from './telemetryReporter';
 import { addHostToHostFile, checkNewHostInHostkeys } from './ssh/hostfile';
 import { DEFAULT_IDENTITY_FILES } from './ssh/identityFiles';
 import { HeartbeatManager } from './heartbeat';
-import { getGitpodVersion, isFeatureSupported } from './featureSupport';
+import { getGitpodVersion, GitpodVersion, isFeatureSupported } from './featureSupport';
 import SSHConfiguration from './ssh/sshConfig';
 import { isWindows } from './common/platform';
 import { untildify } from './common/files';
 import { ExperimentalSettings, isUserOverrideSetting } from './experiments';
+import { ISyncExtension, NoSettingsSyncSession, NoSyncStoreError, parseSyncData, SettingsSync, SyncResource } from './settingsSync';
+import { retry } from './common/async';
 
 interface SSHConnectionParams {
 	workspaceId: string;
@@ -121,6 +123,7 @@ export default class RemoteConnector extends Disposable {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
+		private readonly settingsSync: SettingsSync,
 		private readonly experiments: ExperimentalSettings,
 		private readonly logger: Log,
 		private readonly telemetry: TelemetryReporter
@@ -900,12 +903,76 @@ export default class RemoteConnector extends Disposable {
 		}
 	}
 
-	private startHeartBeat(accessToken: string, connectionInfo: SSHConnectionParams) {
+	private async startHeartBeat(accessToken: string, connectionInfo: SSHConnectionParams, gitpodVersion: GitpodVersion) {
 		if (this.heartbeatManager) {
 			return;
 		}
 
 		this.heartbeatManager = new HeartbeatManager(connectionInfo.gitpodHost, connectionInfo.workspaceId, connectionInfo.instanceId, accessToken, this.logger, this.telemetry);
+
+		// gitpod remote extension installation is async so sometimes gitpod-desktop will activate before gitpod-remote
+		// let's try a few times for it to finish install
+		try {
+			await retry(async () => {
+				await vscode.commands.executeCommand('__gitpod.cancelGitpodRemoteHeartbeat');
+			}, 3000, 15);
+			this.telemetry.sendTelemetryEvent('vscode_desktop_heartbeat_state', { enabled: String(true), gitpodHost: connectionInfo.gitpodHost, workspaceId: connectionInfo.workspaceId, instanceId: connectionInfo.instanceId, gitpodVersion: gitpodVersion.raw });
+		} catch {
+			this.logger.error(`Could not execute '__gitpod.cancelGitpodRemoteHeartbeat' command`);
+			this.telemetry.sendTelemetryEvent('vscode_desktop_heartbeat_state', { enabled: String(false), gitpodHost: connectionInfo.gitpodHost, workspaceId: connectionInfo.workspaceId, instanceId: connectionInfo.instanceId, gitpodVersion: gitpodVersion.raw });
+		}
+	}
+
+	private async initializeRemoteExtensions() {
+		let syncData: { ref: string; content: string } | undefined;
+		try {
+			syncData = await this.settingsSync.readResource(SyncResource.Extensions);
+		} catch (e) {
+			if (e instanceof NoSyncStoreError) {
+				const action = 'Settings Sync: Enable Sign In with Gitpod';
+				const result = await vscode.window.showInformationMessage(`Couldn't initialize remote extensions, Settings Sync with Gitpod is required.`, action);
+				if (result === action) {
+					vscode.commands.executeCommand('gitpod.syncProvider.add');
+				}
+			} else if (e instanceof NoSettingsSyncSession) {
+				const action = 'Enable Settings Sync';
+				const result = await vscode.window.showInformationMessage(`Couldn't initialize remote extensions, please enable Settings Sync.`, action);
+				if (result === action) {
+					vscode.commands.executeCommand('workbench.userDataSync.actions.turnOn');
+				}
+			} else {
+				this.logger.error('Error while fetching settings sync extension data', e);
+			}
+			return;
+		}
+
+		const syncDataContent = parseSyncData(syncData.content);
+		if (!syncDataContent) {
+			this.logger.error('Error while parsing sync data');
+			return;
+		}
+
+		let extensions: ISyncExtension[];
+		try {
+			extensions = JSON.parse(syncDataContent.content);
+		} catch {
+			this.logger.error('Error while parsing settings sync extension data, malformed json');
+			return;
+		}
+
+		extensions = extensions.filter(e => e.installed);
+		if (!extensions.length) {
+			return;
+		}
+
+		try {
+			this.logger.trace(`Try installing extensions on remote: `, extensions.map(e => e.identifier.id).join('\n'));
+			await retry(async () => {
+				await vscode.commands.executeCommand('__gitpod.initializeRemoteExtensions', extensions);
+			}, 3000, 15);
+		} catch {
+			this.logger.error(`Could not execute '__gitpod.initializeRemoteExtensions' command`);
+		}
 	}
 
 	private async onGitpodRemoteConnection() {
@@ -939,27 +1006,12 @@ export default class RemoteConnector extends Disposable {
 
 		const gitpodVersion = await getGitpodVersion(connectionInfo.gitpodHost, this.logger);
 		if (isFeatureSupported(gitpodVersion, 'localHeartbeat')) {
-			// gitpod remote extension installation is async so sometimes gitpod-desktop will activate before gitpod-remote
-			// let's try a few times for it to finish install
-			let retryCount = 15;
-			const tryStopRemoteHeartbeat = async () => {
-				// Check for gitpod remote extension version to avoid sending heartbeat in both extensions at the same time
-				const isGitpodRemoteHeartbeatCancelled = await cancelGitpodRemoteHeartbeat();
-				if (isGitpodRemoteHeartbeatCancelled) {
-					this.telemetry.sendTelemetryEvent('vscode_desktop_heartbeat_state', { enabled: String(true), gitpodHost: connectionInfo.gitpodHost, workspaceId: connectionInfo.workspaceId, instanceId: connectionInfo.instanceId, gitpodVersion: gitpodVersion.raw });
-				} else if (retryCount > 0) {
-					retryCount--;
-					setTimeout(tryStopRemoteHeartbeat, 3000);
-				} else {
-					this.telemetry.sendTelemetryEvent('vscode_desktop_heartbeat_state', { enabled: String(false), gitpodHost: connectionInfo.gitpodHost, workspaceId: connectionInfo.workspaceId, instanceId: connectionInfo.instanceId, gitpodVersion: gitpodVersion.raw });
-				}
-			};
-
-			this.startHeartBeat(session.accessToken, connectionInfo);
-			tryStopRemoteHeartbeat();
+			this.startHeartBeat(session.accessToken, connectionInfo, gitpodVersion);
 		} else {
 			this.logger.warn(`Local heatbeat not supported in ${connectionInfo.gitpodHost}, using version ${gitpodVersion.version}`);
 		}
+
+		this.initializeRemoteExtensions();
 	}
 
 	public override async dispose(): Promise<void> {
@@ -978,17 +1030,6 @@ function isGitpodRemoteWindow(context: vscode.ExtensionContext) {
 	}
 
 	return false;
-}
-
-async function cancelGitpodRemoteHeartbeat() {
-	let result = false;
-	try {
-		// Invoke command from gitpot-remote extension
-		result = await vscode.commands.executeCommand('__gitpod.cancelGitpodRemoteHeartbeat');
-	} catch {
-		// Ignore if not found
-	}
-	return result;
 }
 
 function getServiceURL(gitpodHost: string): string {

--- a/src/settingsSync.ts
+++ b/src/settingsSync.ts
@@ -64,7 +64,7 @@ export interface ISyncData {
 	content: string;
 }
 
-export function isSyncData(thing: any): thing is ISyncData {
+function isSyncData(thing: any): thing is ISyncData {
 	if (thing
 		&& (thing.version !== undefined && typeof thing.version === 'number')
 		&& (thing.content !== undefined && typeof thing.content === 'string')) {

--- a/src/settingsSync.ts
+++ b/src/settingsSync.ts
@@ -250,7 +250,7 @@ export class SettingsSync extends Disposable {
 					'X-Account-Type': 'gitpod',
 					'authorization': `Bearer ${session.accessToken}`,
 				},
-				timeout: 1500
+				timeout: 5000
 			});
 		} catch (e) {
 			throw e;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Initialize remote extensions with extensions from sync server

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7906
Related https://github.com/gitpod-io/openvscode-server/pull/419

## How to test
<!-- Provide steps to test this PR -->
1. Run this extension and connect to workspace 
2. Install this vsix [gitpod-remote-ssh-0.0.39.zip](https://github.com/gitpod-io/gitpod-vscode-desktop/files/9392713/gitpod-remote-ssh-0.0.39.zip) so it's installed by default the second time
3. Disconnect from workspace
4. Enable settings sync
5. Connect to workspace again and check sync extensions are installed in remote server

