### PR TITLE
Support variable scopes

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -223,8 +223,8 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 			});
 
 			const scopeString = sortedFilteredScopes.join(' ');
-			const tokenResp = await this._gitpodServer.login(scopeString);
-			const session = await this.tokenToSession(tokenResp.token, sortedFilteredScopes);
+			const token = await this._gitpodServer.login(scopeString);
+			const session = await this.tokenToSession(token, sortedFilteredScopes);
 
 			const sessions = await this._sessionsPromise;
 			const sessionIndex = sessions.findIndex(s => s.id === session.id || arrayEquals([...s.scopes].sort(), sortedFilteredScopes));

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -90,13 +90,18 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 		return finalSessions;
 	}
 
+	private _validScopes: string[] | undefined;
 	private async fetchValidScopes(): Promise<string[] | undefined> {
+		if (this._validScopes) {
+			return this._validScopes;
+		}
+
 		const endpoint = `${this._serviceUrl}/api/oauth/inspect?client=${vscode.env.uriScheme}-gitpod`;
 		try {
 			const resp = await fetch(endpoint, { timeout: 1500 });
 			if (resp.ok) {
-				const validScopes: string[] = await resp.json();
-				return validScopes;
+				this._validScopes = await resp.json();
+				return this._validScopes;
 			}
 		} catch (e) {
 			this._logger.error(`Error fetching endpoint ${endpoint}`, e);

--- a/src/gitpodServer.ts
+++ b/src/gitpodServer.ts
@@ -20,11 +20,6 @@ interface ExchangeTokenResponse {
 	scope: string;
 }
 
-interface GrantedToken {
-	token: string;
-	scopes: string;
-}
-
 async function getUserInfo(token: string, serviceUrl: string, logger: Log) {
 	const user = await withServerApi(token, serviceUrl, service => service.server.getLoggedInUser(), logger);
 	return {
@@ -40,7 +35,7 @@ export default class GitpodServer extends Disposable {
 	private _serviceUrl: string;
 	private _pendingStates = new Map<string, string[]>();
 	private _pendingVerifiers = new Map<string, string>();
-	private _codeExchangePromises = new Map<string, { promise: Promise<GrantedToken>; cancel: vscode.EventEmitter<void> }>();
+	private _codeExchangePromises = new Map<string, { promise: Promise<string>; cancel: vscode.EventEmitter<void> }>();
 	private _uriEmitter = this._register(new vscode.EventEmitter<vscode.Uri>());
 
 	constructor(serviceUrl: string, private readonly _logger: Log) {
@@ -49,7 +44,7 @@ export default class GitpodServer extends Disposable {
 		this._serviceUrl = serviceUrl.replace(/\/$/, '');
 	}
 
-	public async login(scopes: string): Promise<GrantedToken> {
+	public async login(scopes: string): Promise<string> {
 		this._logger.info(`Logging in for the following scopes: ${scopes}`);
 
 		const callbackUri = await vscode.env.asExternalUri(vscode.Uri.parse(`${vscode.env.uriScheme}://gitpod.gitpod-desktop/complete-gitpod-auth`));
@@ -89,7 +84,7 @@ export default class GitpodServer extends Disposable {
 
 			return Promise.race([
 				codeExchangePromise.promise,
-				new Promise<GrantedToken>((_, reject) => setTimeout(() => reject('Cancelled'), 60000))
+				new Promise<string>((_, reject) => setTimeout(() => reject('Cancelled'), 60000))
 			]).finally(() => {
 				const states = this._pendingStates.get(scopes);
 				if (states) {
@@ -102,7 +97,7 @@ export default class GitpodServer extends Disposable {
 		});
 	}
 
-	private exchangeCodeForToken: (scopes: string) => PromiseAdapter<vscode.Uri, GrantedToken> =
+	private exchangeCodeForToken: (scopes: string) => PromiseAdapter<vscode.Uri, string> =
 		(scopes) => async (uri, resolve, reject) => {
 			const query = new URLSearchParams(uri.query);
 			const code = query.get('code');
@@ -159,7 +154,7 @@ export default class GitpodServer extends Disposable {
 				const exchangeTokenData: ExchangeTokenResponse = await exchangeTokenResponse.json();
 				const jwtToken = exchangeTokenData.access_token;
 				const accessToken = JSON.parse(Buffer.from(jwtToken.split('.')[1], 'base64').toString())['jti'];
-				resolve({token: accessToken, scopes: exchangeTokenData.scope});
+				resolve(accessToken);
 			} catch (err) {
 				reject(err);
 			}

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -25,7 +25,7 @@ import TelemetryReporter from './telemetryReporter';
 import { addHostToHostFile, checkNewHostInHostkeys } from './ssh/hostfile';
 import { DEFAULT_IDENTITY_FILES } from './ssh/identityFiles';
 import { HeartbeatManager } from './heartbeat';
-import { getGitpodVersion, GitpodVersion, isFeatureSupported } from './featureSupport';
+import { getGitpodVersion, GitpodVersion, isFeatureSupported, isOauthInspectSupported, ScopeFeature } from './featureSupport';
 import SSHConfiguration from './ssh/sshConfig';
 import { isWindows } from './common/platform';
 import { untildify } from './common/files';
@@ -522,14 +522,13 @@ export default class RemoteConnector extends Disposable {
 		return preferredIdentityKeys;
 	}
 
-	private async getWorkspaceSSHDestination(accessToken: string, { workspaceId, gitpodHost }: SSHConnectionParams): Promise<{ destination: string; password?: string }> {
+	private async getWorkspaceSSHDestination(session: vscode.AuthenticationSession, { workspaceId, gitpodHost }: SSHConnectionParams): Promise<{ destination: string; password?: string }> {
 		const serviceUrl = new URL(gitpodHost);
-		const gitpodVersion = await getGitpodVersion(gitpodHost, this.logger);
-
-		const [workspaceInfo, ownerToken, registeredSSHKeys] = await withServerApi(accessToken, serviceUrl.toString(), service => Promise.all([
+		const sshKeysSupported = session.scopes.includes(ScopeFeature.SSHPublicKeys);
+		const [workspaceInfo, ownerToken, registeredSSHKeys] = await withServerApi(session.accessToken, serviceUrl.toString(), service => Promise.all([
 			service.server.getWorkspace(workspaceId),
 			service.server.getOwnerToken(workspaceId),
-			isFeatureSupported(gitpodVersion, 'SSHPublicKeys') ? service.server.getSSHPublicKeys() : undefined
+			sshKeysSupported ? service.server.getSSHPublicKeys() : undefined
 		]), this.logger);
 
 		if (workspaceInfo.latestInstance?.status?.phase !== 'running') {
@@ -565,6 +564,7 @@ export default class RemoteConnector extends Disposable {
 			}).connect({
 				host: sshDestInfo.hostName,
 				username: sshDestInfo.user,
+				readyTimeout: 40000,
 				authHandler(_methodsLeft, _partialSuccess, _callback) {
 					return {
 						type: 'password',
@@ -610,7 +610,8 @@ export default class RemoteConnector extends Disposable {
 			if (identityKeys.length) {
 				sshDestInfo.user = `${workspaceId}#${ownerToken}`;
 			}
-			this.logger.warn(`Registered SSH public keys not supported in ${gitpodHost}, using version ${gitpodVersion.version}`);
+			const gitpodVersion = await getGitpodVersion(gitpodHost, this.logger);
+			this.logger.warn(`Registered SSH public keys not supported in ${gitpodHost}, using version ${gitpodVersion.raw}`);
 		}
 
 		return {
@@ -697,11 +698,11 @@ export default class RemoteConnector extends Disposable {
 		return true;
 	}
 
-	private async showSSHPasswordModal(password: string, sshParams: SSHConnectionParams) {
+	private async showSSHPasswordModal(password: string, session: vscode.AuthenticationSession,sshParams: SSHConnectionParams) {
 		const maskedPassword = '•'.repeat(password.length - 3) + password.substring(password.length - 3);
 
+		const sshKeysSupported = session.scopes.includes(ScopeFeature.SSHPublicKeys);
 		const gitpodVersion = await getGitpodVersion(sshParams.gitpodHost, this.logger);
-		const sshKeysSupported = isFeatureSupported(gitpodVersion, 'SSHPublicKeys');
 
 		const copy: vscode.MessageItem = { title: 'Copy' };
 		const configureSSH: vscode.MessageItem = { title: 'Configure SSH' };
@@ -750,10 +751,10 @@ export default class RemoteConnector extends Disposable {
 
 		const gitpodVersion = await getGitpodVersion(gitpodHost, this.logger);
 		const sessionScopes = ['function:getWorkspace', 'function:getOwnerToken', 'function:getLoggedInUser', 'resource:default'];
-		if (isFeatureSupported(gitpodVersion, 'SSHPublicKeys') /* && isFeatureSupported('', 'sendHeartBeat') */) {
+		if (await isOauthInspectSupported(gitpodHost) || isFeatureSupported(gitpodVersion, 'SSHPublicKeys') /* && isFeatureSupported('', 'sendHeartBeat') */) {
 			sessionScopes.push('function:getSSHPublicKeys', 'function:sendHeartBeat');
 		} else {
-			this.logger.warn(`function:getSSHPublicKeys and function:sendHeartBeat session scopes not supported in ${gitpodHost}, using version ${gitpodVersion.version}`);
+			this.logger.warn(`function:getSSHPublicKeys and function:sendHeartBeat session scopes not supported in ${gitpodHost}, using version ${gitpodVersion.raw}`);
 		}
 
 		return vscode.authentication.getSession(
@@ -794,11 +795,11 @@ export default class RemoteConnector extends Disposable {
 			try {
 				this.telemetry.sendRawTelemetryEvent('vscode_desktop_ssh', { kind: 'gateway', status: 'connecting', ...params, gitpodVersion: gitpodVersion.raw, userOverride });
 
-				const { destination, password } = await this.getWorkspaceSSHDestination(session.accessToken, params);
+				const { destination, password } = await this.getWorkspaceSSHDestination(session, params);
 				sshDestination = destination;
 
 				if (password) {
-					await this.showSSHPasswordModal(password, params);
+					await this.showSSHPasswordModal(password, session, params);
 				}
 
 				this.telemetry.sendRawTelemetryEvent('vscode_desktop_ssh', { kind: 'gateway', status: 'connected', ...params, gitpodVersion: gitpodVersion.raw, auth: password ? 'password' : 'key', userOverride });
@@ -1030,11 +1031,12 @@ export default class RemoteConnector extends Disposable {
 
 		await this.context.globalState.update(`${RemoteConnector.SSH_DEST_KEY}${sshDestStr}`, { ...connectionInfo, isFirstConnection: false });
 
+		const heartbeatSupported = session.scopes.includes(ScopeFeature.LocalHeartbeat);
 		const gitpodVersion = await getGitpodVersion(connectionInfo.gitpodHost, this.logger);
-		if (isFeatureSupported(gitpodVersion, 'localHeartbeat')) {
+		if (heartbeatSupported) {
 			this.startHeartBeat(session.accessToken, connectionInfo, gitpodVersion);
 		} else {
-			this.logger.warn(`Local heatbeat not supported in ${connectionInfo.gitpodHost}, using version ${gitpodVersion.version}`);
+			this.logger.warn(`Local heartbeat not supported in ${connectionInfo.gitpodHost}, using version ${gitpodVersion.raw}`);
 		}
 
 		const syncExtensions = vscode.workspace.getConfiguration('gitpod').get<boolean>('remote.syncExtensions')!;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Check for feature support by checking returned session scopes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/12254
Related PR https://github.com/gitpod-io/gitpod/pull/12446

## How to test
<!-- Provide steps to test this PR -->
1. First comment some scope in [related gitpod PR](https://github.com/gitpod-io/gitpod/pull/12446), (I already commented `function:sendHeratbeat`) and build prev env
2. Open workspace in prev env https://jp-oauth-inspect.preview.gitpod-dev.com
3. Connect to workspace from step 2, you'll need to sign in and check heartbeat is disabled in logs
4. Enabled the scope you disabled in step 1 and build prev env
5. Open workspace in prev env https://jp-oauth-inspect.preview.gitpod-dev.com
6. Connect to workspace from step 5, you'll need to sign in again and check heartbeat is enabled in logs

