### PR TITLE
Set default config for stable builds during CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,12 +30,9 @@ jobs:
 
       - name: Generate package.json
         run: |
+          set -e
           node ./scripts/prepare-nightly-build.js -v ${{ github.event.inputs.patchVersion }}
-
-      - name: Override package.json
-        run: |
-          mv ./package.json ./package.json.bak
-          mv ./package.insiders.json ./package.json
+          mv package.insiders.json package.json
 
       - name: Package extension
         id: package_vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,12 @@ jobs:
           jqCommands="${setSegmentKey} | ${setConfigcatKey}"
           cat package.json | jq "${jqCommands}" > package.json.tmp
           mv package.json.tmp package.json
-          node scripts/prepare-release-build
+
+      - name: Generate package.json
+        run: |
+          set -e
+          node ./scripts/prepare-release-build.js
+          mv package.release.json package.json
 
       - name: Package extension
         id: package_vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           jqCommands="${setSegmentKey} | ${setConfigcatKey}"
           cat package.json | jq "${jqCommands}" > package.json.tmp
           mv package.json.tmp package.json
+          node scripts/prepare-release-build
 
       - name: Package extension
         id: package_vsix

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ out/
 .vscode-test/
 *.vsix
 .DS_Store
-package.insiders.json
+package.*.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,4 +12,4 @@ yarn.lock
 .eslintrc.json
 .gitpod.yml
 webpack.config.js
-package.insiders.json
+package.*.json

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,9 +2,6 @@
 
 1. Edit version in [package.json](https://github.com/gitpod-io/gitpod-vscode-desktop/blob/master/package.json)
     - Update version of the extension - this is usually the minor version. **Until the marketplace supports semantic versioning, the minor version should always be an even number. Odd numbers are reserved for the pre-release version of the extension.**
-    - Turn off experimental settings:
-      - `gitpod.remote.useLocalApp: true`
-      - `gitpod.remote.syncExtensions: false`
     - (If necessary) Update vscode engine version
 
 2. If the minor version was increased, run the Nightly action to ensure a new pre-release version with the increased version number is released

--- a/scripts/prepare-nightly-build.js
+++ b/scripts/prepare-nightly-build.js
@@ -30,4 +30,4 @@ const insiderPackageJson = Object.assign(json, {
     version: `${major}.${Number(minor) + 1}.${patch}`
 });
 
-fs.writeFileSync('./package.insiders.json', JSON.stringify(insiderPackageJson, undefined, '\t'));
+fs.writeFileSync('./package.insiders.json', JSON.stringify(insiderPackageJson, undefined, '\t') + '\n');

--- a/scripts/prepare-release-build.js
+++ b/scripts/prepare-release-build.js
@@ -2,16 +2,16 @@
 
 const fs = require("fs");
 
-const manifestPath = "./package.json";
-const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+const releasePackageJson = JSON.parse(fs.readFileSync('./package.json').toString());
 
-const releaseConfig = new Map([
+const releaseDefaultConfig = new Map([
     ["gitpod.remote.useLocalApp", true],
     ["gitpod.remote.syncExtensions", false],
 ]);
 
-for (const [setting, value] of releaseConfig) {
-    manifest.contributes.configuration[0].properties[setting].default = value;
+const gitpodConfig = releasePackageJson.contributes.configuration.find(e => e.title.toLowerCase() === 'gitpod');
+for (const [setting, value] of releaseDefaultConfig) {
+    gitpodConfig.properties[setting].default = value;
 }
 
-fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, "\t") + "\n");
+fs.writeFileSync('./package.release.json', JSON.stringify(releasePackageJson, undefined, '\t') + '\n');

--- a/scripts/prepare-release-build.js
+++ b/scripts/prepare-release-build.js
@@ -1,0 +1,17 @@
+//@ts-check
+
+const fs = require("fs");
+
+const manifestPath = "./package.json";
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+
+const releaseConfig = new Map([
+    ["gitpod.remote.useLocalApp", true],
+    ["gitpod.remote.syncExtensions", false],
+]);
+
+for (const [setting, value] of releaseConfig) {
+    manifest.contributes.configuration[0].properties[setting].default = value;
+}
+
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, "\t") + "\n");


### PR DESCRIPTION
## Description
Ensures (during the automated release process) that release (stable) builds have the correct configuration set and do not use experimental properties only intended for nightly builds at the moment. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12476

## How to test
1. Open a WS with the PR
2. Execute `node scripts/prepare-release-build.js`
3. See the changes that have been made to `package.json`: make sure they changed to values we want for release builds. Those (default) values are:
```json
{
    "gitpod.remote.useLocalApp": true
    "gitpod.remote.syncExtensions": false
}
```
