### PR TITLE
Fix empty SSH config file

### DIFF
--- a/src/ssh/sshConfig.ts
+++ b/src/ssh/sshConfig.ts
@@ -29,12 +29,12 @@ export default class SSHConfiguration {
         const sshConfigPath = getSSHConfigPath();
         let content = '';
         if (await fileExists(sshConfigPath)) {
-            content = await fs.promises.readFile(sshConfigPath, 'utf8');
+            content = (await fs.promises.readFile(sshConfigPath, 'utf8')).trim();
         }
         const config = SSHConfig.parse(content);
 
         if (await fileExists(systemSSHConfig)) {
-            content = await fs.promises.readFile(systemSSHConfig, 'utf8');
+            content = (await fs.promises.readFile(systemSSHConfig, 'utf8')).trim();
             config.push(...SSHConfig.parse(content));
         }
 


### PR DESCRIPTION
## Description
If the SSH config on your machine is empty, our extension reads it as just a single newline (`\n`), which made the SSH config parser scream and shout. 

This PR changes the behavior to always trim the SSH config input, so that this single newline becomes an empty string, which is something the library can deal with.

## Related Issue(s)
n/a - issue was not reported yet, happened to me at least though. 

## How to test
1. Download and install this PR's extension build or run with the Remote Extension Host yourself - [gitpod-desktop-0.0.54.vsix.zip](https://github.com/gitpod-io/gitpod-vscode-desktop/files/9452164/gitpod-desktop-0.0.54.vsix.zip)
2. Ensure your settings have `gitpod.remote.useLocalApp` set to `false`
3. Try connecting to a workspace with both some user SSH config and an empty file (`~/.ssh/config`)
