### PR TITLE
Ask for local app fallback when `Timed out while waiting for handshake`

### DIFF
--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -32,7 +32,7 @@ export class ExperimentalSettings {
         this.extensionVersion = new semver.SemVer(extensionVersion);
     }
 
-    async get<T>(key: string, userId?: string): Promise<T | undefined> {
+    async get<T>(key: string, userId?: string, custom?: { [key: string]: string }): Promise<T | undefined> {
         const config = vscode.workspace.getConfiguration('gitpod');
         const values = config.inspect<T>(key.substring('gitpod.'.length));
         if (!values || !EXPERTIMENTAL_SETTINGS.includes(key)) {
@@ -48,14 +48,14 @@ export class ExperimentalSettings {
             return values.globalValue;
         }
 
-        const user = userId ? new configcatcommon.User(userId) : undefined;
+        const user = userId ? new configcatcommon.User(userId, undefined, undefined, custom) : undefined;
         const configcatKey = key.replace(/\./g, '_'); // '.' are not allowed in configcat
         const experimentValue = (await this.configcatClient.getValueAsync(configcatKey, undefined, user)) as T | undefined;
 
         return experimentValue ?? values.defaultValue;
     }
 
-    async inspect<T>(key: string, userId?: string): Promise<{ key: string; defaultValue?: T; globalValue?: T; experimentValue?: T } | undefined> {
+    async inspect<T>(key: string, userId?: string, custom?: { [key: string]: string }): Promise<{ key: string; defaultValue?: T; globalValue?: T; experimentValue?: T } | undefined> {
         const config = vscode.workspace.getConfiguration('gitpod');
         const values = config.inspect<T>(key.substring('gitpod.'.length));
         if (!values || !EXPERTIMENTAL_SETTINGS.includes(key)) {
@@ -63,7 +63,7 @@ export class ExperimentalSettings {
             return values;
         }
 
-        const user = userId ? new configcatcommon.User(userId) : undefined;
+        const user = userId ? new configcatcommon.User(userId, undefined, undefined, custom) : undefined;
         const configcatKey = key.replace(/\./g, '_'); // '.' are not allowed in configcat
         const experimentValue = (await this.configcatClient.getValueAsync(configcatKey, undefined, user)) as T | undefined;
 

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -808,21 +808,13 @@ export default class RemoteConnector extends Disposable {
 				if (e instanceof NoSSHGatewayError) {
 					this.logger.error('No SSH gateway:', e);
 					const ok = 'OK';
-					const action = await vscode.window.showWarningMessage(`${e.host} does not support [direct SSH access](https://github.com/gitpod-io/gitpod/blob/main/install/installer/docs/workspace-ssh-access.md), connecting via the deprecated SSH tunnel over WebSocket.`, ok);
-					if (action === ok) {
-						// Do nothing and continue execution
-					} else {
-						return;
-					}
+					await vscode.window.showWarningMessage(`${e.host} does not support [direct SSH access](https://github.com/gitpod-io/gitpod/blob/main/install/installer/docs/workspace-ssh-access.md), connecting via the deprecated SSH tunnel over WebSocket.`, ok);
+					// Do nothing and continue execution
 				} else if (e instanceof SSHError && e.message === 'Timed out while waiting for handshake') {
 					this.logger.error('SSH test connection error:', e);
 					const ok = 'OK';
-					const action = await vscode.window.showWarningMessage(`Timed out while waiting for the SSH handshake. It's possible, that SSH connections on port 22 are blocked, or your network is too slow. Connecting via the deprecated SSH tunnel over WebSocket instead.`, ok);
-					if (action === ok) {
-						// Do nothing and continue execution
-					} else {
-						return;
-					}
+					await vscode.window.showWarningMessage(`Timed out while waiting for the SSH handshake. It's possible, that SSH connections on port 22 are blocked, or your network is too slow. Connecting via the deprecated SSH tunnel over WebSocket instead.`, ok);
+					// Do nothing and continue execution
 				} else if (e instanceof NoRunningInstanceError) {
 					this.logger.error('No Running instance:', e);
 					vscode.window.showErrorMessage(`Failed to connect to ${e.workspaceId} Gitpod workspace: workspace not running`);

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -807,7 +807,7 @@ export default class RemoteConnector extends Disposable {
 				this.telemetry.sendRawTelemetryEvent('vscode_desktop_ssh', { kind: 'gateway', status: 'failed', reason: e.toString(), ...params, gitpodVersion: gitpodVersion.raw, userOverride });
 				if (e instanceof NoSSHGatewayError) {
 					this.logger.error('No SSH gateway:', e);
-					const ok = 'Ok';
+					const ok = 'OK';
 					const action = await vscode.window.showWarningMessage(`${e.host} does not support [direct SSH access](https://github.com/gitpod-io/gitpod/blob/main/install/installer/docs/workspace-ssh-access.md), connecting via the deprecated SSH tunnel over WebSocket.`, ok);
 					if (action === ok) {
 						// Do nothing and continue execution
@@ -816,7 +816,7 @@ export default class RemoteConnector extends Disposable {
 					}
 				} else if (e instanceof SSHError && e.message === 'Timed out while waiting for handshake') {
 					this.logger.error('SSH test connection error:', e);
-					const ok = 'Ok';
+					const ok = 'OK';
 					const action = await vscode.window.showWarningMessage(`Timed out while waiting for SSH handshake, it's possible SSH connections on port 22 are blocked or your network is too slow, connecting via the deprecated SSH tunnel over WebSocket.`, ok);
 					if (action === ok) {
 						// Do nothing and continue execution

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -817,7 +817,7 @@ export default class RemoteConnector extends Disposable {
 				} else if (e instanceof SSHError && e.message === 'Timed out while waiting for handshake') {
 					this.logger.error('SSH test connection error:', e);
 					const ok = 'OK';
-					const action = await vscode.window.showWarningMessage(`Timed out while waiting for SSH handshake, it's possible SSH connections on port 22 are blocked or your network is too slow, connecting via the deprecated SSH tunnel over WebSocket.`, ok);
+					const action = await vscode.window.showWarningMessage(`Timed out while waiting for the SSH handshake. It's possible, that SSH connections on port 22 are blocked, or your network is too slow. Connecting via the deprecated SSH tunnel over WebSocket instead.`, ok);
 					if (action === ok) {
 						// Do nothing and continue execution
 					} else {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ask for local app fallback when `Timed out while waiting for handshake`
Add `gitpodHost` custom attribute to configcat

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12475

## How to test
1. Block ssh connections and check a notification is shown, Clicking Ok will fallback to use local-app

To block port 22 you can follow https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-with-ufw-on-ubuntu-18-04 if you are on linux
