### PR TITLE
flow analytics against vscode apis

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -12,6 +12,8 @@ import Log from './common/logger';
 import { arrayEquals } from './common/utils';
 import { Disposable } from './common/dispose';
 import TelemetryReporter from './telemetryReporter';
+import { UserFlowTelemetry } from './common/telemetry';
+import { NotificationService } from './notification';
 
 interface SessionData {
 	id: string;
@@ -28,35 +30,30 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 	private _sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
 	private _logger: Log;
 	private _telemetry: TelemetryReporter;
-	private _gitpodServer: GitpodServer;
-	private _keychain: Keychain;
 
-	private _serviceUrl: string;
+	private _gitpodServer!: GitpodServer;
+	private _keychain!: Keychain;
+	private _serviceUrl!: string;
 
 	private _sessionsPromise: Promise<vscode.AuthenticationSession[]>;
 
-	constructor(private readonly context: vscode.ExtensionContext, logger: Log, telemetry: TelemetryReporter) {
+	private readonly flow: Readonly<UserFlowTelemetry> = { flow: 'auth' };
+
+	constructor(
+		private readonly context: vscode.ExtensionContext,
+		logger: Log,
+		telemetry: TelemetryReporter,
+		private readonly notifications: NotificationService
+	) {
 		super();
 
 		this._logger = logger;
 		this._telemetry = telemetry;
 
-		const gitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
-		const gitpodHostUrl = new URL(gitpodHost);
-		this._serviceUrl = gitpodHostUrl.toString().replace(/\/$/, '');
-		this._gitpodServer = new GitpodServer(this._serviceUrl, this._logger);
-		this._keychain = new Keychain(this.context, `gitpod.auth.${gitpodHostUrl.hostname}`, this._logger);
-		this._logger.info(`Started authentication provider for ${gitpodHost}`);
+		this.reconcile();
 		this._register(vscode.workspace.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('gitpod.host')) {
-				const gitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
-				const gitpodHostUrl = new URL(gitpodHost);
-				this._serviceUrl = gitpodHostUrl.toString().replace(/\/$/, '');
-				this._gitpodServer.dispose();
-				this._gitpodServer = new GitpodServer(this._serviceUrl, this._logger);
-				this._keychain = new Keychain(this.context, `gitpod.auth.${gitpodHostUrl.hostname}`, this._logger);
-				this._logger.info(`Started authentication provider for ${gitpodHost}`);
-
+				this.reconcile();
 				this.checkForUpdates();
 			}
 		}));
@@ -66,6 +63,17 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 
 		this._register(vscode.authentication.registerAuthenticationProvider('gitpod', 'Gitpod', this, { supportsMultipleAccounts: false }));
 		this._register(this.context.secrets.onDidChange(() => this.checkForUpdates()));
+	}
+
+	private reconcile(): void {
+		const gitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
+		const gitpodHostUrl = new URL(gitpodHost);
+		this._serviceUrl = gitpodHostUrl.toString().replace(/\/$/, '');
+		Object.assign(this.flow, { gitpodHost: this._serviceUrl });
+		this._gitpodServer?.dispose();
+		this._gitpodServer = new GitpodServer(this._serviceUrl, this._logger, this.notifications);
+		this._keychain = new Keychain(this.context, `gitpod.auth.${gitpodHostUrl.hostname}`, this._logger);
+		this._logger.info(`Started authentication provider for ${gitpodHost}`);
 	}
 
 	get onDidChangeSessions() {
@@ -213,6 +221,7 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 	}
 
 	public async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
+		const flow = { ...this.flow };
 		try {
 			// For the Gitpod scope list, order doesn't matter so we immediately sort the scopes
 			const sortedScopes = scopes.sort();
@@ -221,15 +230,13 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 			if (sortedScopes.length !== sortedFilteredScopes.length) {
 				this._logger.warn(`Creating session with only valid scopes ${sortedFilteredScopes.join(',')}, original scopes were ${sortedScopes.join(',')}`);
 			}
-
-			this._telemetry.sendRawTelemetryEvent('gitpod_desktop_auth', {
-				kind: 'login',
-				scopes: JSON.stringify(sortedFilteredScopes),
-			});
+			flow.scopes = JSON.stringify(sortedFilteredScopes);
+			this._telemetry.sendUserFlowStatus('login', flow);
 
 			const scopeString = sortedFilteredScopes.join(' ');
-			const token = await this._gitpodServer.login(scopeString);
+			const token = await this._gitpodServer.login(scopeString, flow);
 			const session = await this.tokenToSession(token, sortedFilteredScopes);
+			flow.userId = session.account.id;
 
 			const sessions = await this._sessionsPromise;
 			const sessionIndex = sessions.findIndex(s => s.id === session.id || arrayEquals([...s.scopes].sort(), sortedFilteredScopes));
@@ -244,19 +251,16 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 
 			this._logger.info('Login success!');
 
-			this._telemetry.sendRawTelemetryEvent('gitpod_desktop_auth', { kind: 'login_successful' });
+			this._telemetry.sendUserFlowStatus('login_successful', flow);
 
 			return session;
 		} catch (e) {
 			// If login was cancelled, do not notify user.
 			if (e === 'Cancelled' || e.message === 'Cancelled') {
-				this._telemetry.sendRawTelemetryEvent('gitpod_desktop_auth', { kind: 'login_cancelled' });
+				this._telemetry.sendUserFlowStatus('login_cancelled', flow);
 				throw e;
 			}
-
-			this._telemetry.sendRawTelemetryEvent('gitpod_desktop_auth', { kind: 'login_failed' });
-
-			vscode.window.showErrorMessage(`Sign in failed: ${e}`);
+			this.notifications.showErrorMessage(`Sign in failed: ${e}`, { flow, id: 'login_failed' });
 			this._logger.error(e);
 			throw e;
 		}
@@ -273,15 +277,16 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 	}
 
 	public async removeSession(id: string) {
+		const flow = { ...this.flow };
 		try {
-			this._telemetry.sendRawTelemetryEvent('gitpod_desktop_auth', { kind: 'logout' });
-
+			this._telemetry.sendUserFlowStatus('logout', flow);
 			this._logger.info(`Logging out of ${id}`);
 
 			const sessions = await this._sessionsPromise;
 			const sessionIndex = sessions.findIndex(session => session.id === id);
 			if (sessionIndex > -1) {
 				const session = sessions[sessionIndex];
+				flow.userId = session.account.id;
 				sessions.splice(sessionIndex, 1);
 
 				await this.storeSessions(sessions);
@@ -290,10 +295,9 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 			} else {
 				this._logger.error('Session not found');
 			}
+			this._telemetry.sendUserFlowStatus('logout_successful', flow);
 		} catch (e) {
-			this._telemetry.sendRawTelemetryEvent('gitpod_desktop_auth', { kind: 'logout_failed' });
-
-			vscode.window.showErrorMessage(`Sign out failed: ${e}`);
+			this.notifications.showErrorMessage(`Sign out failed: ${e}`, { flow, id: 'logout_failed' });
 			this._logger.error(e);
 			throw e;
 		}

--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -8,6 +8,22 @@
 import * as vscode from 'vscode';
 import { Disposable } from './dispose';
 
+export interface TelemetryOptions {
+	gitpodHost?: string;
+	gitpodVersion?: string;
+
+	workspaceId?: string;
+	instanceId?: string;
+
+	userId?: string
+
+	[prop: string]: any
+}
+
+export interface UserFlowTelemetry extends TelemetryOptions {
+	flow: string
+}
+
 const enum TelemetryLevel {
 	ON = 'on',
 	ERROR = 'error',
@@ -371,6 +387,12 @@ export class BaseTelemetryReporter extends Disposable {
 			const cleanProperties = this.cloneAndChange(properties, (_key: string, prop: string) => this.anonymizeFilePaths(prop, false));
 			this.telemetryAppender.logEvent(`${eventName}`, { properties: this.removePropertiesWithPossibleUserInfo(cleanProperties) });
 		}
+	}
+
+	sendUserFlowStatus(status: string, flow: UserFlowTelemetry): void {
+		const properties: TelemetryOptions = { ...flow, status };
+		delete properties['flow'];
+		this.sendRawTelemetryEvent('vscode_desktop_' + flow.flow, properties);
 	}
 
 	/**

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -10,7 +10,8 @@ import * as semver from 'semver';
 import Log from './common/logger';
 
 const EXPERTIMENTAL_SETTINGS = [
-    'gitpod.remote.useLocalApp'
+    'gitpod.remote.useLocalApp',
+    'gitpod.remote.syncExtensions'
 ];
 
 export class ExperimentalSettings {

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitpod. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { UserFlowTelemetry } from './common/telemetry';
+import TelemetryReporter from './telemetryReporter';
+
+export interface NotificationOption extends vscode.MessageOptions {
+    id: string
+    flow: UserFlowTelemetry
+}
+
+export class NotificationService {
+
+    constructor(
+        private readonly telemetry: TelemetryReporter
+    ) { }
+
+    showInformationMessage<T extends vscode.MessageItem | string>(message: string, option: NotificationOption, ...items: T[]): Promise<T | undefined> {
+        return this.withTelemetry<T>(option, 'info', () =>
+            vscode.window.showInformationMessage(message, option, ...<any[]>items)
+        );
+    }
+
+    showWarningMessage<T extends vscode.MessageItem | string>(message: string, option: NotificationOption, ...items: T[]): Promise<T | undefined> {
+        return this.withTelemetry<T>(option, 'warning', () =>
+            vscode.window.showWarningMessage(message, option, ...<any[]>items)
+        );
+    }
+
+    showErrorMessage<T extends vscode.MessageItem | string>(message: string, option: NotificationOption, ...items: T[]): Promise<T | undefined> {
+        return this.withTelemetry<T>(option, 'error', () =>
+            vscode.window.showErrorMessage(message, option, ...<any[]>items)
+        );
+    }
+
+    private async withTelemetry<T extends vscode.MessageItem | string>(option: NotificationOption, severity: 'info' | 'warning' | 'error', cb: () => PromiseLike<T | undefined>): Promise<T | undefined> {
+        const startTime = new Date().getTime();
+        let element = option.id;
+        if (option.modal === true) {
+            element += '_modal';
+        } else {
+            element += '_notification';
+        }
+        const flowOptions = { ...option.flow, severity };
+        this.telemetry.sendUserFlowStatus('show_' + element, flowOptions);
+        let result: T | undefined;
+        try {
+            result = await cb();
+        } finally {
+            const duration = new Date().getTime() - startTime;
+            const closed = result === undefined || (typeof result === 'object' && result.isCloseAffordance == true);
+            const status = closed ? 'close_' + element : 'select_' + element + '_action';
+            const action = typeof result === 'string' ? result : result?.title;
+            this.telemetry.sendUserFlowStatus(status, { ...flowOptions, action, duration });
+        }
+        return result;
+    }
+
+}

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -941,7 +941,7 @@ export default class RemoteConnector extends Disposable {
 	private async initializeRemoteExtensions(flow: UserFlowTelemetry) {
 		let syncData: { ref: string; content: string } | undefined;
 		try {
-			syncData = await this.settingsSync.readResource(SyncResource.Extensions, flow.gitpodHost!);
+			syncData = await this.settingsSync.readResource(SyncResource.Extensions);
 		} catch (e) {
 			if (e instanceof NoSyncStoreError) {
 				const addSyncProvider = 'Settings Sync: Enable Sign In with Gitpod';


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR normalize analytics events and prepares an experiment for synching local extensions: 
- all events start with `vscode_desktop_` prefix to distinguish from other
- events are instrumented with information about host, user and workspace
- events have `flow` and `status` properties, like `ssh`, `settings-sync`, `sync_local_extensions` flows
- VS Code notifications contribute to flows automatically by instrumenting VS Code APIs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Debug extension, check out analytics in the lab project while connecting via remote ssh and synching local extensions.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
 