### PR TITLE
[config-cat] refresh settings values once in a minute on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,12 @@
 				"command": "gitpod.showReleaseNotes",
 				"category": "Gitpod",
 				"title": "Show Release Notes"
+			},
+			{
+				"command": "gitpod.dev.refreshExperiments",
+				"category": "Developer",
+				"title": "Refresh Gitpod Experiments",
+				"enablement": "gitpod.dev"
 			}
 		]
 	},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With this PR we refresh ConfigCat settings values only once in a minute on demand.

You can test by using `Developer: Refresh Gitpod Experiments` command and observing last refresh date and time diff relative to it. If diff is over 60000 milliseconds new refresh happens. This command is available only while running from sources. The logic should work across multiple windows, so if you restart the debug session you should see that previous should be respected.

<img width="1496" alt="Screenshot 2022-09-08 at 09 59 03" src="https://user-images.githubusercontent.com/3082655/189073172-0ec16e3d-94d9-4e0a-99f9-bbfda1805c6b.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
