### PR TITLE
quiet installation of local extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"onCommand:gitpod.exportLogs",
 		"onCommand:gitpod.api.autoTunnel",
 		"onCommand:gitpod.showReleaseNotes",
+		"onCommand:gitpod.installLocalExtensions",
 		"onAuthenticationRequest:gitpod",
 		"onUri",
 		"onStartupFinished"
@@ -62,12 +63,6 @@
 						"type": "boolean",
 						"description": "Use the local companion app to connect to a remote workspace.\nWarning: Connecting to a remote workspace using local companion app will be removed in the near future.",
 						"default": false,
-						"scope": "application"
-					},
-					"gitpod.remote.syncExtensions": {
-						"type": "boolean",
-						"description": "Automatically install sync extensions from Gitpod Sync Server on the remote workspace.",
-						"default": true,
 						"scope": "application"
 					}
 				}
@@ -105,8 +100,22 @@
 				"command": "gitpod.showReleaseNotes",
 				"category": "Gitpod",
 				"title": "Show Release Notes"
+			},
+			{
+				"command": "gitpod.installLocalExtensions",
+				"title": "Gitpod: Install Local Extensions...",
+				"enablement": "gitpod.inWorkspace == true"
 			}
-		]
+		],
+		"menus": {
+			"statusBar/remoteIndicator": [
+				{
+					"command": "gitpod.installLocalExtensions",
+					"group": "remote_00_gitpod_navigation@01",
+					"when": "gitpod.inWorkspace == true"
+				}
+			]
+		}
 	},
 	"main": "./out/extension.js",
 	"segmentKey": "YErmvd89wPsrCuGcVnF2XAl846W9WIGl",

--- a/scripts/prepare-release-build.js
+++ b/scripts/prepare-release-build.js
@@ -6,7 +6,6 @@ const releasePackageJson = JSON.parse(fs.readFileSync('./package.json').toString
 
 const releaseDefaultConfig = new Map([
     ["gitpod.remote.useLocalApp", true],
-    ["gitpod.remote.syncExtensions", false],
 ]);
 
 const gitpodConfig = releasePackageJson.contributes.configuration.find(e => e.title.toLowerCase() === 'gitpod');

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -10,8 +10,7 @@ import * as semver from 'semver';
 import Log from './common/logger';
 
 const EXPERTIMENTAL_SETTINGS = [
-    'gitpod.remote.useLocalApp',
-    'gitpod.remote.syncExtensions'
+    'gitpod.remote.useLocalApp'
 ];
 
 export class ExperimentalSettings {

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,9 +93,9 @@
     google-protobuf "^3.19.1"
 
 "@gitpod/public-api@main":
-  version "0.1.5-main.5229"
-  resolved "https://registry.yarnpkg.com/@gitpod/public-api/-/public-api-0.1.5-main.5229.tgz#81873d255b1f0aa9b1c8ba8216c3354c68f5ab64"
-  integrity sha512-Vy9GZfL5nmh7oSSoEDEmJrqw+mrpN3+4CyVQENtGAvJ71hJ6U4F3sZ8ZnEpBe37aiBoY7dx+ZHSGNrKElkFMyQ==
+  version "0.1.5-main.5286"
+  resolved "https://registry.yarnpkg.com/@gitpod/public-api/-/public-api-0.1.5-main.5286.tgz#ddb9f70c1c35fdf2d38826308d5c258a4dfffd3b"
+  integrity sha512-E0EX+lh+QEq9/WKBb3EemKjNDoIYdzK3XBbjU/9ajWxyXfh7Knls7ysk5dS9mf0r/HBIzI40QDLl8lvS3TX5lQ==
   dependencies:
     "@bufbuild/connect-web" "^0.2.1"
     "@bufbuild/protobuf" "^0.1.1"


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

Since many users ignore this notification, only 40% of users who noticed it managed to convert, and around 1% of all users never come back if they try to use we decided to quiet this notification on the connection. Instead it logs and we provide an explicit `Install Local Extensions` command to force sync at any time which will prompt a user.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7906

## How to test
<!-- Provide steps to test this PR -->

- Start debugging an extension from this branch.
- Disable Setting Sync with Gitpod.
- Using debug window connect to Gitpod workspace in gitpod.io
- Check that on connection you don't have notifications, but in logs there are error messages that installing local extension failed with a link to enabling Setting Sync with Gitpod.

<img width="1012" alt="Screenshot 2022-10-20 at 14 02 19" src="https://user-images.githubusercontent.com/3082655/196947893-77b727ff-2f64-4459-b029-ed31222b618b.png">

- Click on the remote indicator and select `Install Local Extensions` new command.

<img width="647" alt="Screenshot 2022-10-20 at 14 05 21" src="https://user-images.githubusercontent.com/3082655/196948061-955c63dd-ff9e-4910-aba3-23e1518dac11.png">

- This time you should see notifications taking you through the flow.

<img width="532" alt="Screenshot 2022-10-20 at 14 05 26" src="https://user-images.githubusercontent.com/3082655/196948126-e26883e1-d721-48f0-806e-56f1da77de68.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add `Install Local Extensions` command to explicitly install local extensions.
On connection try to install local extensions but quietly without notifications.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
I will do https://github.com/gitpod-io/website/issues/2933 after this PR is merged and deployed for latest and stable.