### PR TITLE
Option for disabling release notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,12 @@
 						"default": "https://gitpod.io/",
 						"scope": "application"
 					},
+					"gitpod.enableReleaseNotes": {
+						"type": "boolean",
+						"description": "Enable showing the Gitpod Changelog whenever a new one comes out.",
+						"default": true,
+						"scope": "application"
+					},
 					"gitpod.remote.useLocalApp": {
 						"type": "boolean",
 						"description": "Use the local companion app to connect to a remote workspace.\nWarning: Connecting to a remote workspace using local companion app will be removed in the near future.",

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
 						"default": "https://gitpod.io/",
 						"scope": "application"
 					},
-					"gitpod.enableReleaseNotes": {
+					"gitpod.showReleaseNotes": {
 						"type": "boolean",
-						"description": "Enable showing the Gitpod Changelog whenever a new one comes out.",
+						"description": "Show the Gitpod Changelog whenever a new one comes out.",
 						"default": true,
 						"scope": "application"
 					},

--- a/src/common/cache.ts
+++ b/src/common/cache.ts
@@ -40,12 +40,15 @@ export class CacheHelper {
 		return now > data.expiration ? undefined : data.value;
 	}
 
-	async getOrRefresh<T>(key: string, refreshCallback: () => Thenable<{ value: T; ttl?: number }>): Promise<T> {
+	async getOrRefresh<T>(key: string, refreshCallback: () => Thenable<{ value: T; ttl?: number }>): Promise<T | undefined> {
 		let value = this.get<T>(key);
 		if (value === undefined) {
-			const result = await refreshCallback();
-			await this.set(key, result.value, result.ttl);
-			value = result.value;
+			try {
+				const result = await refreshCallback();
+				await this.set(key, result.value, result.ttl);
+				value = result.value;
+			} catch {
+			}
 		}
 		return value;
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,13 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	}));
 
-	context.subscriptions.push(new ReleaseNotes(context));
+	if (vscode.workspace.getConfiguration('gitpod').get<boolean>('enableReleaseNotes')) {
+		const lastRead = context.globalState.get<string>(ReleaseNotes.RELEASE_NOTES_LAST_READ_KEY);
+		logger.info(`Last read release notes: ${lastRead}`);
+		context.subscriptions.push(new ReleaseNotes(context));
+	} else {
+		logger.info('Release notes are disabled');
+	}
 
 	if (!context.globalState.get<boolean>(FIRST_INSTALL_KEY, false)) {
 		await context.globalState.update(FIRST_INSTALL_KEY, true);

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -70,6 +70,9 @@ export class ReleaseNotes extends Disposable {
 				ttl: this.getResponseCacheTime(resp),
 			};
 		});
+		if (!md) {
+			return;
+		}
 
 		const parseInfo = (md: string) => {
 			if (!md.startsWith('---')) {
@@ -112,7 +115,15 @@ export class ReleaseNotes extends Disposable {
 		}
 
 		const releaseId = await this.getLastPublish();
+		if (!releaseId) {
+			return;
+		}
+
 		const mdContent = await this.loadChangelog(releaseId);
+		if (!mdContent) {
+			return;
+		}
+
 		const html = await vscode.commands.executeCommand<string>('markdown.api.render', mdContent);
 		this.panel.webview.html = `<!DOCTYPE html>
 <html lang="en">
@@ -142,10 +153,13 @@ export class ReleaseNotes extends Disposable {
 	}
 
 	private async showIfNewRelease(lastReadId: string | undefined) {
-		const releaseId = await this.getLastPublish();
-		console.log(`gitpod release notes lastReadId: ${lastReadId}, latestReleaseId: ${releaseId}`);
-		if (releaseId !== lastReadId) {
-			this.createOrShow();
+		const showReleaseNotes = vscode.workspace.getConfiguration('gitpod').get<boolean>('showReleaseNotes');
+		if (showReleaseNotes) {
+			const releaseId = await this.getLastPublish();
+			if (releaseId && releaseId !== lastReadId) {
+				console.log(`gitpod release notes lastReadId: ${lastReadId}, latestReleaseId: ${releaseId}`);
+				this.createOrShow();
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR contributes a new option, `gitpod.enableReleaseNotes`. This is `true` by default and if turned off, it completely disables the release notes logic for VS Code Desktop.

A hotfix for https://github.com/gitpod-io/gitpod/issues/14533