### PR TITLE
Force Linux host platform for Windows users

### DIFF
--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -474,7 +474,7 @@ export default class RemoteConnector extends Disposable {
 		const sshHostKeys = (await sshHostKeyResponse.json()) as { type: string; host_key: string }[];
 		let user = workspaceId;
 		// See https://github.com/gitpod-io/gitpod/pull/9786 for reasoning about `.ssh` suffix
-		let hostName = workspaceUrl.host.replace(workspaceId, `${workspaceId}.ssh`)
+		let hostName = workspaceUrl.host.replace(workspaceId, `${workspaceId}.ssh`);
 		if (debugWorkspace) {
 			user = 'debug-' + workspaceId;
 			hostName = hostName.replace(workspaceId, user);
@@ -819,7 +819,8 @@ export default class RemoteConnector extends Disposable {
 		if (process.platform === 'win32') {
 			const existingSSHHostPlatforms = vscode.workspace.getConfiguration('remote.SSH').get<{[host: string]: string}>('remotePlatform') || {};
 			if (!Object.keys(existingSSHHostPlatforms).includes(params.workspaceId)) {
-				vscode.workspace.getConfiguration('remote.SSH').update('remotePlatform', { ...existingSSHHostPlatforms, [params.workspaceId]: 'linux' }, vscode.ConfigurationTarget.Global);
+				const workspaceHost = JSON.parse(Buffer.from(sshDestination!, 'hex').toString()).hostName;
+				vscode.workspace.getConfiguration('remote.SSH').update('remotePlatform', { ...existingSSHHostPlatforms, [workspaceHost]: 'linux' }, vscode.ConfigurationTarget.Global);
 			}
 		}
 

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -818,8 +818,8 @@ export default class RemoteConnector extends Disposable {
 		// Force Linux as host platform (https://github.com/gitpod-io/gitpod/issues/16058)
 		if (process.platform === 'win32') {
 			const existingSSHHostPlatforms = vscode.workspace.getConfiguration('remote.SSH').get<{[host: string]: string}>('remotePlatform') || {};
-			if (!Object.keys(existingSSHHostPlatforms).includes(params.workspaceId)) {
-				const workspaceHost = JSON.parse(Buffer.from(sshDestination!, 'hex').toString()).hostName;
+			const workspaceHost: string | undefined = JSON.parse(Buffer.from(sshDestination!, 'hex').toString()).hostName;
+			if (workspaceHost && !Object.keys(existingSSHHostPlatforms).includes(workspaceHost)) {
 				vscode.workspace.getConfiguration('remote.SSH').update('remotePlatform', { ...existingSSHHostPlatforms, [workspaceHost]: 'linux' }, vscode.ConfigurationTarget.Global);
 			}
 		}

--- a/src/ssh/sshDestination.ts
+++ b/src/ssh/sshDestination.ts
@@ -41,4 +41,19 @@ export default class SSHDestination {
         }
         return result;
     }
+
+    toRemoteSSHString() {
+        if (typeof this.user === 'undefined' && typeof this.port === 'undefined') {
+            return this.hostname;
+        }
+
+        const obj: any = { hostName: this.hostname };
+        if (typeof this.user !== 'undefined') {
+            obj.user = this.user;
+        }
+        if (typeof this.port !== 'undefined') {
+            obj.port = this.port;
+        }
+        return Buffer.from(JSON.stringify(obj), 'utf8').toString('hex');
+    }
 }

--- a/src/ssh/sshDestination.ts
+++ b/src/ssh/sshDestination.ts
@@ -43,15 +43,15 @@ export default class SSHDestination {
     }
 
     toRemoteSSHString() {
-        if (typeof this.user === 'undefined' && typeof this.port === 'undefined') {
+        if (!this.user && !this.port) {
             return this.hostname;
         }
 
         const obj: any = { hostName: this.hostname };
-        if (typeof this.user !== 'undefined') {
+        if (this.user) {
             obj.user = this.user;
         }
-        if (typeof this.port !== 'undefined') {
+        if (this.port) {
             obj.port = this.port;
         }
         return Buffer.from(JSON.stringify(obj), 'utf8').toString('hex');


### PR DESCRIPTION
## Description
Force VS Code to think the server it's connecting to is a Linux host, which caused detection problems on Windows. 

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/16058

## How to test
1. Connect to a workspace with VS Code Desktop (if you can, go get a Windows machine for this)
2. Don't get the OS prompt
