### PR TITLE
Readd `onResolveRemoteAuthority:ssh-remote` and fix for configuration default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		}
 	},
 	"activationEvents": [
+		"onResolveRemoteAuthority:ssh-remote",
 		"onCommand:gitpod.syncProvider.add",
 		"onCommand:gitpod.syncProvider.remove",
 		"onCommand:gitpod.exportLogs",

--- a/scripts/prepare-release-build.js
+++ b/scripts/prepare-release-build.js
@@ -4,13 +4,4 @@ const fs = require("fs");
 
 const releasePackageJson = JSON.parse(fs.readFileSync('./package.json').toString());
 
-const releaseDefaultConfig = new Map([
-    ["gitpod.remote.useLocalApp", true],
-]);
-
-const gitpodConfig = releasePackageJson.contributes.configuration.find(e => e.title.toLowerCase() === 'gitpod');
-for (const [setting, value] of releaseDefaultConfig) {
-    gitpodConfig.properties[setting].default = value;
-}
-
 fs.writeFileSync('./package.release.json', JSON.stringify(releasePackageJson, undefined, '\t') + '\n');

--- a/src/authentication/authentication.ts
+++ b/src/authentication/authentication.ts
@@ -12,6 +12,7 @@ import { Disposable } from '../common/dispose';
 import { ITelemetryService, UserFlowTelemetry } from '../services/telemetryService';
 import { INotificationService } from '../services/notificationService';
 import { ILogService } from '../services/logService';
+import { Configuration } from '../configuration';
 
 interface SessionData {
 	id: string;
@@ -59,7 +60,7 @@ export default class GitpodAuthenticationProvider extends Disposable implements 
 	}
 
 	private reconcile(): void {
-		const gitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
+		const gitpodHost = Configuration.getGitpodHost();
 		const gitpodHostUrl = new URL(gitpodHost);
 		this._serviceUrl = gitpodHostUrl.toString().replace(/\/$/, '');
 		Object.assign(this.flow, { gitpodHost: this._serviceUrl });

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Gitpod. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+// Use these functions instead of `vscode.workspace.getConfiguration` API
+// When activating the extension early with `onResolveRemoteAuthority:ssh-remote`, default values
+// are not available yet and will return `undefined` so we hardcode the defaults here
+
+function getGitpodHost() {
+    return vscode.workspace.getConfiguration('gitpod').get<string>('host', 'https://gitpod.io/');
+}
+
+function getShowReleaseNotes() {
+    return vscode.workspace.getConfiguration('gitpod').get<boolean>('showReleaseNotes', true);
+}
+
+function getUseLocalApp() {
+    return vscode.workspace.getConfiguration('gitpod').get<boolean>('remote.useLocalApp', false);
+}
+
+export const Configuration = {
+    getGitpodHost,
+    getShowReleaseNotes,
+    getUseLocalApp
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,95 +35,101 @@ if (!global.fetch) {
 const FIRST_INSTALL_KEY = 'gitpod-desktop.firstInstall';
 
 let telemetryService: TelemetryService;
-let remoteSession: RemoteSession;
+let remoteSession: RemoteSession | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
 	const extensionId = context.extension.id;
 	const packageJSON = context.extension.packageJSON;
 
-	// sync between machines
-	context.globalState.setKeysForSync([ReleaseNotes.RELEASE_NOTES_LAST_READ_KEY]);
+	try {
+		// sync between machines
+		context.globalState.setKeysForSync([ReleaseNotes.RELEASE_NOTES_LAST_READ_KEY]);
 
-	const logger = vscode.window.createOutputChannel('Gitpod', { log: true });
-	context.subscriptions.push(logger);
+		const logger = vscode.window.createOutputChannel('Gitpod', { log: true });
+		context.subscriptions.push(logger);
 
-	const onDidChangeLogLevel = (logLevel: vscode.LogLevel) => {
-		logger.info(`Log level: ${vscode.LogLevel[logLevel]}`);
-	};
-	context.subscriptions.push(logger.onDidChangeLogLevel(onDidChangeLogLevel));
-	onDidChangeLogLevel(logger.logLevel);
+		const onDidChangeLogLevel = (logLevel: vscode.LogLevel) => {
+			logger.info(`Log level: ${vscode.LogLevel[logLevel]}`);
+		};
+		context.subscriptions.push(logger.onDidChangeLogLevel(onDidChangeLogLevel));
+		onDidChangeLogLevel(logger.logLevel);
 
-	logger.info(`${extensionId}/${packageJSON.version} (${os.release()} ${os.platform()} ${os.arch()}) vscode/${vscode.version} (${vscode.env.appName})`);
+		logger.info(`${extensionId}/${packageJSON.version} (${os.release()} ${os.platform()} ${os.arch()}) vscode/${vscode.version} (${vscode.env.appName})`);
 
-	telemetryService = new TelemetryService(extensionId, packageJSON.version, packageJSON.segmentKey);
+		telemetryService = new TelemetryService(extensionId, packageJSON.version, packageJSON.segmentKey);
 
-	const notificationService = new NotificationService(telemetryService);
+		const notificationService = new NotificationService(telemetryService);
 
-	const commandManager = new CommandManager();
-	context.subscriptions.push(commandManager);
+		const commandManager = new CommandManager();
+		context.subscriptions.push(commandManager);
 
-	// Create auth provider as soon as possible
-	const authProvider = new GitpodAuthenticationProvider(context, logger, telemetryService, notificationService);
-	context.subscriptions.push(authProvider);
+		// Create auth provider as soon as possible
+		const authProvider = new GitpodAuthenticationProvider(context, logger, telemetryService, notificationService);
+		context.subscriptions.push(authProvider);
 
-	const hostService = new HostService(context, notificationService, logger);
-	context.subscriptions.push(hostService);
+		const hostService = new HostService(context, notificationService, logger);
+		context.subscriptions.push(hostService);
 
-	const sessionService = new SessionService(hostService, logger);
-	context.subscriptions.push(sessionService);
+		const sessionService = new SessionService(hostService, logger);
+		context.subscriptions.push(sessionService);
 
-	const experiments = new ExperimentalSettings('gitpod', packageJSON.version, sessionService, context, logger);
-	context.subscriptions.push(experiments);
+		const experiments = new ExperimentalSettings('gitpod', packageJSON.version, sessionService, context, logger);
+		context.subscriptions.push(experiments);
 
-	const settingsSync = new SettingsSync(commandManager, logger, telemetryService, notificationService);
-	context.subscriptions.push(settingsSync);
+		const settingsSync = new SettingsSync(commandManager, logger, telemetryService, notificationService);
+		context.subscriptions.push(settingsSync);
 
-	const remoteConnector = new RemoteConnector(context, sessionService, hostService, experiments, logger, telemetryService, notificationService);
-	context.subscriptions.push(remoteConnector);
+		const remoteConnector = new RemoteConnector(context, sessionService, hostService, experiments, logger, telemetryService, notificationService);
+		context.subscriptions.push(remoteConnector);
 
-	context.subscriptions.push(vscode.window.registerUriHandler({
-		handleUri(uri: vscode.Uri) {
-			// logger.trace('Handling Uri...', uri.toString());
-			if (uri.path === GitpodServer.AUTH_COMPLETE_PATH) {
-				authProvider.handleUri(uri);
-			} else {
-				remoteConnector.handleUri(uri);
+		context.subscriptions.push(vscode.window.registerUriHandler({
+			handleUri(uri: vscode.Uri) {
+				// logger.trace('Handling Uri...', uri.toString());
+				if (uri.path === GitpodServer.AUTH_COMPLETE_PATH) {
+					authProvider.handleUri(uri);
+				} else {
+					remoteConnector.handleUri(uri);
+				}
 			}
+		}));
+
+		context.subscriptions.push(new ReleaseNotes(context, commandManager, logger));
+
+		// Register global commands
+		commandManager.register(new SignInCommand(sessionService));
+		commandManager.register(new ExportLogsCommand(context.logUri, notificationService, telemetryService, logger));
+
+		const remoteConnectionInfo = getGitpodRemoteWindowConnectionInfo(context);
+		telemetryService.sendTelemetryEvent('vscode_desktop_activate', {
+			remoteName: vscode.env.remoteName || '',
+			remoteUri: String(!!(vscode.workspace.workspaceFile || vscode.workspace.workspaceFolders?.[0].uri)),
+			workspaceId: remoteConnectionInfo?.connectionInfo.workspaceId || '',
+			instanceId: remoteConnectionInfo?.connectionInfo.instanceId || '',
+			gitpodHost: remoteConnectionInfo?.connectionInfo.gitpodHost || '',
+			debugWorkspace: remoteConnectionInfo ? String(!!remoteConnectionInfo.connectionInfo.debugWorkspace) : '',
+		});
+
+		if (!context.globalState.get<boolean>(FIRST_INSTALL_KEY, false)) {
+			context.globalState.update(FIRST_INSTALL_KEY, true);
+			telemetryService.sendTelemetryEvent('gitpod_desktop_installation', { kind: 'install' });
 		}
-	}));
 
-	const remoteConnectionInfo = getGitpodRemoteWindowConnectionInfo(context);
-	if (remoteConnectionInfo) {
-		commandManager.register({ id: 'gitpod.api.autoTunnel', execute: () => remoteConnector.autoTunnelCommand });
+		// Because auth provider implementation is in the same extension, we need to wait for it to activate first
+		sessionService.didFirstLoad.then(async () => {
+			if (remoteConnectionInfo) {
+				commandManager.register({ id: 'gitpod.api.autoTunnel', execute: () => remoteConnector.autoTunnelCommand });
 
-		remoteSession = new RemoteSession(remoteConnectionInfo.remoteAuthority, remoteConnectionInfo.connectionInfo, context, hostService, sessionService, settingsSync, experiments, logger, telemetryService, notificationService);
-		// Don't await this on purpose so it doesn't block extension activation.
-		// Internally requesting a Gitpod Session requires the extension to be already activated.
-		remoteSession.initialize();
-	} else if (sessionService.isSignedIn()) {
-		const restartFlow = { flow: 'restart_workspace', userId: sessionService.getUserId() };
-		checkForStoppedWorkspaces(context, hostService.gitpodHost, restartFlow, notificationService, logger);
+				remoteSession = new RemoteSession(remoteConnectionInfo.remoteAuthority, remoteConnectionInfo.connectionInfo, context, hostService, sessionService, settingsSync, experiments, logger, telemetryService, notificationService);
+				await remoteSession.initialize();
+			} else if (sessionService.isSignedIn()) {
+				const restartFlow = { flow: 'restart_workspace', userId: sessionService.getUserId() };
+				checkForStoppedWorkspaces(context, hostService.gitpodHost, restartFlow, notificationService, logger);
+			}
+		});
+	} catch (e) {
+		telemetryService?.sendTelemetryException(e);
+		throw e;
 	}
-
-	context.subscriptions.push(new ReleaseNotes(context, commandManager, logger));
-
-	if (!context.globalState.get<boolean>(FIRST_INSTALL_KEY, false)) {
-		await context.globalState.update(FIRST_INSTALL_KEY, true);
-		telemetryService.sendTelemetryEvent('gitpod_desktop_installation', { kind: 'install' });
-	}
-
-	// Register global commands
-	commandManager.register(new SignInCommand(sessionService));
-	commandManager.register(new ExportLogsCommand(context.logUri, notificationService, telemetryService, logger));
-
-	telemetryService.sendTelemetryEvent('vscode_desktop_activate', {
-		remoteName: vscode.env.remoteName || '',
-		remoteUri: String(!!(vscode.workspace.workspaceFile || vscode.workspace.workspaceFolders?.[0].uri)),
-		workspaceId: remoteConnectionInfo?.connectionInfo.workspaceId || '',
-		instanceId: remoteConnectionInfo?.connectionInfo.instanceId || '',
-		gitpodHost: remoteConnectionInfo?.connectionInfo.gitpodHost || '',
-		debugWorkspace: remoteConnectionInfo ? String(!!remoteConnectionInfo.connectionInfo.debugWorkspace) : '',
-	});
 }
 
 export async function deactivate() {

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -9,6 +9,7 @@ import { CacheHelper } from './common/cache';
 import { Disposable, disposeAll } from './common/dispose';
 import { ILogService } from './services/logService';
 import { CommandManager } from './commandManager';
+import { Configuration } from './configuration';
 
 export class ReleaseNotes extends Disposable {
 	public static readonly viewType = 'gitpodReleaseNotes';
@@ -162,7 +163,7 @@ export class ReleaseNotes extends Disposable {
 	}
 
 	private async showIfNewRelease(lastReadId: string | undefined) {
-		const showReleaseNotes = vscode.workspace.getConfiguration('gitpod').get<boolean>('showReleaseNotes');
+		const showReleaseNotes = Configuration.getShowReleaseNotes();
 		if (showReleaseNotes) {
 			const releaseId = await this.getLastPublish();
 			if (releaseId && releaseId !== lastReadId) {

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -37,6 +37,7 @@ import { NoRunningInstanceError, NoSSHGatewayError, SSHConnectionParams, SSH_DES
 import { ISessionService } from './services/sessionService';
 import { ILogService } from './services/logService';
 import { IHostService } from './services/hostService';
+import { Configuration } from './configuration';
 
 interface LocalAppConfig {
 	gitpodHost: string;
@@ -650,9 +651,7 @@ export class RemoteConnector extends Disposable {
 		this.usePublicApi = await this.experiments.getRaw<boolean>('gitpod_experimental_publicApi', { gitpodHost: params.gitpodHost }) ?? false;
 		this.logService.info(`Going to use ${this.usePublicApi ? 'public' : 'server'} API`);
 
-		const forceUseLocalApp = getServiceURL(params.gitpodHost) === 'https://gitpod.io'
-			? (await this.experiments.get<boolean>('gitpod.remote.useLocalApp', { gitpodHost: params.gitpodHost }))!
-			: (await this.experiments.get<boolean>('gitpod.remote.useLocalApp', { gitpodHost: params.gitpodHost }, 'gitpod_remote_useLocalApp_sh'))!;
+		const forceUseLocalApp = Configuration.getUseLocalApp();
 		const userOverride = String(isUserOverrideSetting('gitpod.remote.useLocalApp'));
 		let sshDestination: SSHDestination | undefined;
 		if (!forceUseLocalApp) {
@@ -766,9 +765,7 @@ export class RemoteConnector extends Disposable {
 
 	public async autoTunnelCommand(gitpodHost: string, instanceId: string, enabled: boolean) {
 		if (this.sessionService.isSignedIn()) {
-			const forceUseLocalApp = getServiceURL(gitpodHost) === 'https://gitpod.io'
-				? (await this.experiments.get<boolean>('gitpod.remote.useLocalApp', { gitpodHost }))!
-				: (await this.experiments.get<boolean>('gitpod.remote.useLocalApp', { gitpodHost }, 'gitpod_remote_useLocalApp_sh'))!;
+			const forceUseLocalApp = Configuration.getUseLocalApp();
 			if (!forceUseLocalApp) {
 				const authority = vscode.Uri.parse(gitpodHost).authority;
 				const configKey = `config/${authority}`;

--- a/src/remoteSession.ts
+++ b/src/remoteSession.ts
@@ -53,9 +53,6 @@ export class RemoteSession extends Disposable {
 	public async initialize() {
 		this.logService.info('On remote window, RemoteSession initializing');
 
-		// Because auth provider implementation is in the same extension, we need to wait for it to activate first
-		await this.sessionService.didFirstLoad;
-
 		if (!this.sessionService.isSignedIn()) {
 			this.showSignInDialog();
 			return;

--- a/src/services/hostService.ts
+++ b/src/services/hostService.ts
@@ -10,6 +10,7 @@ import { INotificationService } from './notificationService';
 import { getGitpodRemoteWindowConnectionInfo } from '../remote';
 import { UserFlowTelemetry } from './telemetryService';
 import { ILogService } from './logService';
+import { Configuration } from '../configuration';
 
 export interface IHostService {
     gitpodHost: string;
@@ -39,11 +40,11 @@ export class HostService extends Disposable implements IHostService {
     ) {
         super();
 
-        this._gitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
+        this._gitpodHost = Configuration.getGitpodHost();
 
         this._register(vscode.workspace.onDidChangeConfiguration(e => {
             if (e.affectsConfiguration('gitpod.host')) {
-                const newGitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
+                const newGitpodHost = Configuration.getGitpodHost();
                 if (new URL(this._gitpodHost).host !== new URL(newGitpodHost).host) {
                     this._gitpodHost = newGitpodHost;
                     this._version = undefined;

--- a/src/services/telemetryService.ts
+++ b/src/services/telemetryService.ts
@@ -7,6 +7,7 @@ import { AppenderData, BaseTelemetryAppender, BaseTelemetryClient, BaseTelemetry
 import { Analytics } from '@segment/analytics-node';
 import * as os from 'os';
 import * as vscode from 'vscode';
+import { Configuration } from '../configuration';
 
 const analyticsClientFactory = async (key: string): Promise<BaseTelemetryClient> => {
 	let segmentAnalyticsClient = new Analytics({ writeKey: key });
@@ -25,7 +26,7 @@ const analyticsClientFactory = async (key: string): Promise<BaseTelemetryClient>
 			}
 		},
 		logException: (exception: Error, data?: AppenderData) => {
-			const gitpodHost = vscode.workspace.getConfiguration('gitpod').get<string>('host')!;
+			const gitpodHost = Configuration.getGitpodHost();
 			const serviceUrl = new URL(gitpodHost);
 			const errorMetricsEndpoint = `https://ide.${serviceUrl.hostname}/metrics-api/reportError`;
 

--- a/src/settingsSync.ts
+++ b/src/settingsSync.ts
@@ -9,6 +9,7 @@ import { INotificationService } from './services/notificationService';
 import { ITelemetryService, UserFlowTelemetry } from './services/telemetryService';
 import { ILogService } from './services/logService';
 import { CommandManager } from './commandManager';
+import { Configuration } from './configuration';
 
 export class NoSyncStoreError extends Error {
 	constructor() {
@@ -219,8 +220,7 @@ export class SettingsSync extends Disposable {
 	}
 
 	private getServiceUrl() {
-		const config = vscode.workspace.getConfiguration();
-		const serviceUrl = new URL(config.get<string>('gitpod.host')!);
+		const serviceUrl = new URL(Configuration.getGitpodHost());
 		serviceUrl.pathname = '/code-sync';
 		return serviceUrl;
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When activating the extension early with `onResolveRemoteAuthority:ssh-remote`, configuration default values are not available yet and will return `undefined` so we hardcode the defaults

## How to test
<!-- Provide steps to test this PR -->
- Ensure you don't have changed any gitpod configuration in your settings.json if so then remove it first, so default values are used
- Try connecting to a workspace in gitpod.io as this is the default value, connection should be successful and the extension is activated
