### PR TITLE
Graceful restart local ssh daemon

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,7 @@
+
 tasks:
   - init: yarn install
+
+vscode:
+  extensions:
+    - zxh404.vscode-proto3

--- a/src/daemonStarter.ts
+++ b/src/daemonStarter.ts
@@ -22,6 +22,7 @@ export async function ensureDaemonStarted(logService: ILogService, telemetryServ
             logService.error(`lssh exit with code ${humanReadableCode} ${code}`);
             switch (code) {
                 case ExitCode.OK:
+                case ExitCode.UpgradeRestart:
                 case ExitCode.ListenPortFailed:
                     resolve(true);
                     return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,7 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const remoteConnector = new RemoteConnector(context, sessionService, hostService, experiments, logger, telemetryService, notificationService);
 		context.subscriptions.push(remoteConnector);
 
-		const extensionIPCService = new ExtensionServiceServer(logger, sessionService, hostService, notificationService, telemetryService, experiments);
+		const extensionIPCService = new ExtensionServiceServer(packageJSON.version, logger, sessionService, hostService, notificationService, telemetryService, experiments);
 		context.subscriptions.push(extensionIPCService);
 
 		context.subscriptions.push(vscode.window.registerUriHandler({

--- a/src/local-ssh/common.ts
+++ b/src/local-ssh/common.ts
@@ -23,6 +23,7 @@ export enum ExitCode {
 	ListenPortFailed = 100,
 	UnexpectedError = 101,
 	InvalidOptions = 102,
+	UpgradeRestart = 103,
 }
 
 export function exitProcess(code: ExitCode) {

--- a/src/local-ssh/ipc/extension.ts
+++ b/src/local-ssh/ipc/extension.ts
@@ -68,7 +68,7 @@ export class ExtensionServiceImpl implements ExtensionServiceImplementation {
             }
             const userId = this.sessionService.getUserId();
             const workspaceId = request.workspaceId;
-            
+
             const gitpodHost = this.hostService.gitpodHost;
             const usePublicApi = await this.experiments.getUsePublicAPI(gitpodHost);
             const [workspace, ownerToken] = await withServerApi(accessToken, gitpodHost, svc => Promise.all([
@@ -149,7 +149,7 @@ export class ExtensionServiceImpl implements ExtensionServiceImplementation {
     async getCurrentExtensionVersion(_request: getCurrentExtensionVersionRequest, _context: CallContext): Promise<{ version?: string | undefined; }> {
         return { version: this.extensionVersion };
     }
-    
+
     async tryRestartDaemon(_request: TryRestartDaemonRequest, _context: CallContext): Promise<{}> {
         this.logService.info('daemon requested to restart');
         this._onDidDaemonRestartRequired.fire();
@@ -181,10 +181,10 @@ export class ExtensionServiceServer extends Disposable {
 
         this.createLocalSSHClient();
         vscode.workspace.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('gitpod.lsshIpcPort')) {
+            if (e.affectsConfiguration('gitpod.lsshIpcPort')) {
                 this.createLocalSSHClient();
-			}
-		})
+            }
+        });
     }
 
     private createLocalSSHClient() {
@@ -204,7 +204,7 @@ export class ExtensionServiceServer extends Disposable {
         serviceImpl.onDidDaemonRestartRequired(() => {
             ensureDaemonStarted(this.logService, this.telemetryService, 3).then().catch(e => {
                 this.logService.debug('failed to start local SSH daemon: ' + e.toString());
-            })
+            });
         });
         return server;
     }

--- a/src/local-ssh/ipc/extension.ts
+++ b/src/local-ssh/ipc/extension.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionServiceDefinition, ExtensionServiceImplementation, GetWorkspaceAuthInfoRequest, GetWorkspaceAuthInfoResponse, LocalSSHServiceDefinition, PingRequest, SendErrorReportRequest, SendLocalSSHUserFlowStatusRequest, SendLocalSSHUserFlowStatusRequest_Code, SendLocalSSHUserFlowStatusRequest_ConnType, SendLocalSSHUserFlowStatusRequest_Status } from '../../proto/typescript/ipc/v1/ipc';
+import vscode from 'vscode';
+import { ExtensionServiceDefinition, ExtensionServiceImplementation, GetWorkspaceAuthInfoRequest, GetWorkspaceAuthInfoResponse, LocalSSHServiceDefinition, PingRequest, SendErrorReportRequest, SendLocalSSHUserFlowStatusRequest, SendLocalSSHUserFlowStatusRequest_Code, SendLocalSSHUserFlowStatusRequest_ConnType, SendLocalSSHUserFlowStatusRequest_Status, TryRestartDaemonRequest, getCurrentExtensionVersionRequest } from '../../proto/typescript/ipc/v1/ipc';
 import { Disposable } from '../../common/dispose';
-import { retry, timeout } from '../../common/async';
+import { timeout } from '../../common/async';
 export { ExtensionServiceDefinition } from '../../proto/typescript/ipc/v1/ipc';
-import { ensureDaemonStarted } from '../../daemonStarter';
 import { withServerApi } from '../../internalApi';
 import { Workspace, WorkspaceInstanceStatus_Phase } from '@gitpod/public-api/lib/gitpod/experimental/v1';
 import { WorkspaceInfo, WorkspaceInstancePhase } from '@gitpod/gitpod-protocol';
@@ -15,14 +15,13 @@ import { ILogService } from '../../services/logService';
 import { ISessionService } from '../../services/sessionService';
 import { CallContext, ServerError, Status } from 'nice-grpc-common';
 import { IHostService } from '../../services/hostService';
-import { Server, createClient, createServer, createChannel } from 'nice-grpc';
-import { getDaemonVersion } from '../common';
+import { Server, createClient, createServer, createChannel, Client, Channel } from 'nice-grpc';
 import { INotificationService } from '../../services/notificationService';
 import { showWsNotRunningDialog } from '../../remote';
 import { ITelemetryService, UserFlowTelemetry } from '../../services/telemetryService';
 import { ExperimentalSettings } from '../../experiments';
-import { SemVer } from 'semver';
 import { Configuration } from '../../configuration';
+import { ensureDaemonStarted } from '../../daemonStarter';
 
 const phaseMap: Record<WorkspaceInstanceStatus_Phase, WorkspaceInstancePhase | undefined> = {
     [WorkspaceInstanceStatus_Phase.CREATING]: 'pending',
@@ -40,7 +39,10 @@ const phaseMap: Record<WorkspaceInstanceStatus_Phase, WorkspaceInstancePhase | u
 export class ExtensionServiceImpl implements ExtensionServiceImplementation {
     private notificationGapSet = new Set<string>();
 
-    constructor(private logService: ILogService, private sessionService: ISessionService, private hostService: IHostService, private notificationService: INotificationService, private experiments: ExperimentalSettings, private telemetryService: ITelemetryService) { }
+    private readonly _onDidDaemonRestartRequired = new vscode.EventEmitter<void>();
+    public readonly onDidDaemonRestartRequired = this._onDidDaemonRestartRequired.event;
+
+    constructor(private readonly extensionVersion: string, private logService: ILogService, private sessionService: ISessionService, private hostService: IHostService, private notificationService: INotificationService, private experiments: ExperimentalSettings, private telemetryService: ITelemetryService) { }
 
     private canShowNotification(id: string) {
         if (this.notificationGapSet.has(id)) {
@@ -143,21 +145,29 @@ export class ExtensionServiceImpl implements ExtensionServiceImplementation {
         this.telemetryService.sendTelemetryException(request.gitpodHost, err, properties);
         return {};
     }
+
+    async getCurrentExtensionVersion(_request: getCurrentExtensionVersionRequest, _context: CallContext): Promise<{ version?: string | undefined; }> {
+        return { version: this.extensionVersion };
+    }
+    
+    async tryRestartDaemon(_request: TryRestartDaemonRequest, _context: CallContext): Promise<{}> {
+        this.logService.info('daemon requested to restart');
+        this._onDidDaemonRestartRequired.fire();
+        return {};
+    }
 }
 
 export class ExtensionServiceServer extends Disposable {
-    static MAX_LOCAL_SSH_PING_RETRY_COUNT = 10;
-    static MAX_EXTENSION_ACTIVE_RETRY_COUNT = 10;
-
     private server: Server;
-    private pingLocalSSHRetryCount = 0;
     private lastTimeActiveTelemetry: boolean | undefined;
     private readonly id: string = Math.random().toString(36).slice(2);
     private ipcPort?: number;
 
-    private localSSHServiceClient = createClient(LocalSSHServiceDefinition, createChannel('127.0.0.1:' + Configuration.getLocalSshIpcPort()));
+    private localSSHServiceChannel?: Channel;
+    private localSSHServiceClient?: Client<LocalSSHServiceDefinition>;
 
     constructor(
+        private readonly extensionVersion: string,
         private readonly logService: ILogService,
         private readonly sessionService: ISessionService,
         private readonly hostService: IHostService,
@@ -168,15 +178,34 @@ export class ExtensionServiceServer extends Disposable {
         super();
         this.server = this.getServer();
         this.tryActive();
-        this.hostService.onDidChangeHost(() => {
-            this.tryActive();
-        });
+
+        this.createLocalSSHClient();
+        vscode.workspace.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('gitpod.lsshIpcPort')) {
+                this.createLocalSSHClient();
+			}
+		})
+    }
+
+    private createLocalSSHClient() {
+        if (this.localSSHServiceChannel) {
+            this.localSSHServiceChannel.close();
+            this.localSSHServiceChannel = undefined;
+        }
+        const channel = createChannel('127.0.0.1:' + Configuration.getLocalSshIpcPort());
+        this.localSSHServiceClient = createClient(LocalSSHServiceDefinition, channel);
+        this.localSSHServiceChannel = channel;
     }
 
     private getServer(): Server {
         const server = createServer();
-        const serviceImpl = new ExtensionServiceImpl(this.logService, this.sessionService, this.hostService, this.notificationService, this.experiments, this.telemetryService);
+        const serviceImpl = new ExtensionServiceImpl(this.extensionVersion, this.logService, this.sessionService, this.hostService, this.notificationService, this.experiments, this.telemetryService);
         server.add(ExtensionServiceDefinition, serviceImpl);
+        serviceImpl.onDidDaemonRestartRequired(() => {
+            ensureDaemonStarted(this.logService, this.telemetryService, 3).then().catch(e => {
+                this.logService.debug('failed to start local SSH daemon: ' + e.toString());
+            })
+        });
         return server;
     }
 
@@ -185,22 +214,26 @@ export class ExtensionServiceServer extends Disposable {
         this.server.listen('127.0.0.1:0').then((port) => {
             this.ipcPort = port;
             this.logService.info('extension ipc service server started to listen with id: ' + this.id);
-            this.pingLocalSSHService();
-            this.backoffActive();
+            this.setExtensionActivedForDaemon();
         }).catch(e => {
             this.logService.error(e, `extension ipc service server failed to listen with id: ${this.id}`);
         });
     }
 
-    private async backoffActive() {
+    private async setExtensionActivedForDaemon() {
+        while (true) {
+            this.actualSetExtensionActivedForDaemon();
+            await timeout(1000 * 1);
+        }
+    }
+
+    private async actualSetExtensionActivedForDaemon() {
         try {
-            await retry(async () => {
-                await this.localSSHServiceClient.active({ id: this.id, ipcPort: this.ipcPort! });
-                this.logService.info('extension ipc svc activated id: ' + this.id);
-            }, 200, ExtensionServiceServer.MAX_EXTENSION_ACTIVE_RETRY_COUNT);
-            if (this.lastTimeActiveTelemetry === true) {
+            if (!this.localSSHServiceClient) {
                 return;
             }
+            await this.localSSHServiceClient.active({ id: this.id, ipcPort: this.ipcPort! });
+            this.logService.info('extension ipc svc activated id: ' + this.id);
             const userId = this.sessionService.safeGetUserId();
             this.telemetryService.sendRawTelemetryEvent(this.hostService.gitpodHost, 'vscode_desktop_extension_ipc_svc_active', { id: this.id, userId, active: true });
             this.lastTimeActiveTelemetry = true;
@@ -219,43 +252,5 @@ export class ExtensionServiceServer extends Disposable {
 
     public override dispose() {
         this.server.shutdown();
-    }
-
-    /**
-     * pingLocalSSHService to see if it's still alive
-     * if not, start a new one
-     */
-    private async pingLocalSSHService() {
-        while (true) {
-            if (this.pingLocalSSHRetryCount > ExtensionServiceServer.MAX_LOCAL_SSH_PING_RETRY_COUNT) {
-                this.logService.error('failed to ping local ssh service for 10 times, stopping ping process');
-                return;
-            }
-            try {
-                await this.localSSHServiceClient.ping({});
-                this.pingLocalSSHRetryCount = 0;
-                this.notifyIfDaemonNeedsRestart().catch(e => {
-                    this.logService.error(e, 'failed to notify if daemon needs restart');
-                });
-            } catch (err) {
-                this.logService.error('failed to ping local ssh service, going to start a new one', err);
-                ensureDaemonStarted(this.logService, this.telemetryService).catch(() => { });
-                this.backoffActive();
-                this.pingLocalSSHRetryCount++;
-            }
-            await timeout(1000 * 1);
-        }
-    }
-
-    private async notifyIfDaemonNeedsRestart() {
-        const resp = await this.localSSHServiceClient.getDaemonVersion({});
-        const runningVersion = new SemVer(resp.version);
-        const wantedVersion = new SemVer(getDaemonVersion());
-        if (runningVersion.compare(wantedVersion) >= 0) {
-            return;
-        }
-        // TODO(local-ssh): allow to hide always for current version (wantedVersion)
-        this.logService.info('restart vscode to get latest features of local ssh');
-        // await this.notificationService.showWarningMessage('Restart VSCode to use latest local ssh daemon', { id: 'daemon_needs_restart', flow: { flow: 'daemon_needs_restart' } });
     }
 }

--- a/src/proto/ipc/v1/ipc.proto
+++ b/src/proto/ipc/v1/ipc.proto
@@ -8,6 +8,11 @@ service LocalSSHService {
 
     // Inactive is called when extension is deactivated
     rpc Inactive(InactiveRequest) returns (InactiveResponse) {}
+
+    rpc Ping (PingRequest) returns (PingResponse) {}
+
+    // GetDaemonVersion returns the version of the daemon
+    rpc GetDaemonVersion(GetDaemonVersionRequest) returns (GetDaemonVersionResponse) {}
 }
 
 service ExtensionService {
@@ -104,6 +109,12 @@ message InactiveResponse {}
 message PingRequest {}
 
 message PingResponse {}
+
+message GetDaemonVersionRequest {}
+
+message GetDaemonVersionResponse {
+    string version = 1;
+}
 
 message GetWorkspaceAuthInfoRequest {
     string workspace_id = 1;

--- a/src/proto/ipc/v1/ipc.proto
+++ b/src/proto/ipc/v1/ipc.proto
@@ -8,11 +8,6 @@ service LocalSSHService {
 
     // Inactive is called when extension is deactivated
     rpc Inactive(InactiveRequest) returns (InactiveResponse) {}
-
-    rpc Ping (PingRequest) returns (PingResponse) {}
-
-    // GetDaemonVersion returns the version of the daemon
-    rpc GetDaemonVersion(GetDaemonVersionRequest) returns (GetDaemonVersionResponse) {}
 }
 
 service ExtensionService {
@@ -20,6 +15,17 @@ service ExtensionService {
     rpc GetWorkspaceAuthInfo (GetWorkspaceAuthInfoRequest) returns (GetWorkspaceAuthInfoResponse) {}
     rpc SendLocalSSHUserFlowStatus (SendLocalSSHUserFlowStatusRequest) returns (SendLocalSSHUserFlowStatusResponse) {}
     rpc SendErrorReport (SendErrorReportRequest) returns (SendErrorReportResponse) {}
+    rpc GetCurrentExtensionVersion (GetCurrentExtensionVersionRequest) returns (GetCurrentExtensionVersionResponse) {}
+    rpc TryRestartDaemon (TryRestartDaemonRequest) returns (TryRestartDaemonResponse) {}
+}
+
+message TryRestartDaemonRequest {}
+message TryRestartDaemonResponse {}
+
+message GetCurrentExtensionVersionRequest {}
+
+message GetCurrentExtensionVersionResponse {
+    string version = 1;
 }
 
 message SendErrorReportRequest {
@@ -98,12 +104,6 @@ message InactiveResponse {}
 message PingRequest {}
 
 message PingResponse {}
-
-message GetDaemonVersionRequest {}
-
-message GetDaemonVersionResponse {
-    string version = 1;
-}
 
 message GetWorkspaceAuthInfoRequest {
     string workspace_id = 1;

--- a/src/proto/typescript/ipc/v1/ipc.ts
+++ b/src/proto/typescript/ipc/v1/ipc.ts
@@ -4,6 +4,19 @@ import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "ipc.v1";
 
+export interface TryRestartDaemonRequest {
+}
+
+export interface TryRestartDaemonResponse {
+}
+
+export interface GetCurrentExtensionVersionRequest {
+}
+
+export interface GetCurrentExtensionVersionResponse {
+  version: string;
+}
+
 export interface SendErrorReportRequest {
   workspaceId: string;
   instanceId: string;
@@ -214,13 +227,6 @@ export interface PingRequest {
 export interface PingResponse {
 }
 
-export interface GetDaemonVersionRequest {
-}
-
-export interface GetDaemonVersionResponse {
-  version: string;
-}
-
 export interface GetWorkspaceAuthInfoRequest {
   workspaceId: string;
 }
@@ -233,6 +239,186 @@ export interface GetWorkspaceAuthInfoResponse {
   gitpodHost: string;
   userId: string;
 }
+
+function createBaseTryRestartDaemonRequest(): TryRestartDaemonRequest {
+  return {};
+}
+
+export const TryRestartDaemonRequest = {
+  encode(_: TryRestartDaemonRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TryRestartDaemonRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTryRestartDaemonRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): TryRestartDaemonRequest {
+    return {};
+  },
+
+  toJSON(_: TryRestartDaemonRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<TryRestartDaemonRequest>): TryRestartDaemonRequest {
+    return TryRestartDaemonRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial(_: DeepPartial<TryRestartDaemonRequest>): TryRestartDaemonRequest {
+    const message = createBaseTryRestartDaemonRequest();
+    return message;
+  },
+};
+
+function createBaseTryRestartDaemonResponse(): TryRestartDaemonResponse {
+  return {};
+}
+
+export const TryRestartDaemonResponse = {
+  encode(_: TryRestartDaemonResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TryRestartDaemonResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTryRestartDaemonResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): TryRestartDaemonResponse {
+    return {};
+  },
+
+  toJSON(_: TryRestartDaemonResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<TryRestartDaemonResponse>): TryRestartDaemonResponse {
+    return TryRestartDaemonResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial(_: DeepPartial<TryRestartDaemonResponse>): TryRestartDaemonResponse {
+    const message = createBaseTryRestartDaemonResponse();
+    return message;
+  },
+};
+
+function createBaseGetCurrentExtensionVersionRequest(): GetCurrentExtensionVersionRequest {
+  return {};
+}
+
+export const GetCurrentExtensionVersionRequest = {
+  encode(_: GetCurrentExtensionVersionRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetCurrentExtensionVersionRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetCurrentExtensionVersionRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): GetCurrentExtensionVersionRequest {
+    return {};
+  },
+
+  toJSON(_: GetCurrentExtensionVersionRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<GetCurrentExtensionVersionRequest>): GetCurrentExtensionVersionRequest {
+    return GetCurrentExtensionVersionRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial(_: DeepPartial<GetCurrentExtensionVersionRequest>): GetCurrentExtensionVersionRequest {
+    const message = createBaseGetCurrentExtensionVersionRequest();
+    return message;
+  },
+};
+
+function createBaseGetCurrentExtensionVersionResponse(): GetCurrentExtensionVersionResponse {
+  return { version: "" };
+}
+
+export const GetCurrentExtensionVersionResponse = {
+  encode(message: GetCurrentExtensionVersionResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetCurrentExtensionVersionResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetCurrentExtensionVersionResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.version = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetCurrentExtensionVersionResponse {
+    return { version: isSet(object.version) ? String(object.version) : "" };
+  },
+
+  toJSON(message: GetCurrentExtensionVersionResponse): unknown {
+    const obj: any = {};
+    message.version !== undefined && (obj.version = message.version);
+    return obj;
+  },
+
+  create(base?: DeepPartial<GetCurrentExtensionVersionResponse>): GetCurrentExtensionVersionResponse {
+    return GetCurrentExtensionVersionResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial(object: DeepPartial<GetCurrentExtensionVersionResponse>): GetCurrentExtensionVersionResponse {
+    const message = createBaseGetCurrentExtensionVersionResponse();
+    message.version = object.version ?? "";
+    return message;
+  },
+};
 
 function createBaseSendErrorReportRequest(): SendErrorReportRequest {
   return {
@@ -887,100 +1073,6 @@ export const PingResponse = {
   },
 };
 
-function createBaseGetDaemonVersionRequest(): GetDaemonVersionRequest {
-  return {};
-}
-
-export const GetDaemonVersionRequest = {
-  encode(_: GetDaemonVersionRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): GetDaemonVersionRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGetDaemonVersionRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(_: any): GetDaemonVersionRequest {
-    return {};
-  },
-
-  toJSON(_: GetDaemonVersionRequest): unknown {
-    const obj: any = {};
-    return obj;
-  },
-
-  create(base?: DeepPartial<GetDaemonVersionRequest>): GetDaemonVersionRequest {
-    return GetDaemonVersionRequest.fromPartial(base ?? {});
-  },
-
-  fromPartial(_: DeepPartial<GetDaemonVersionRequest>): GetDaemonVersionRequest {
-    const message = createBaseGetDaemonVersionRequest();
-    return message;
-  },
-};
-
-function createBaseGetDaemonVersionResponse(): GetDaemonVersionResponse {
-  return { version: "" };
-}
-
-export const GetDaemonVersionResponse = {
-  encode(message: GetDaemonVersionResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.version !== "") {
-      writer.uint32(10).string(message.version);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): GetDaemonVersionResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGetDaemonVersionResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.version = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): GetDaemonVersionResponse {
-    return { version: isSet(object.version) ? String(object.version) : "" };
-  },
-
-  toJSON(message: GetDaemonVersionResponse): unknown {
-    const obj: any = {};
-    message.version !== undefined && (obj.version = message.version);
-    return obj;
-  },
-
-  create(base?: DeepPartial<GetDaemonVersionResponse>): GetDaemonVersionResponse {
-    return GetDaemonVersionResponse.fromPartial(base ?? {});
-  },
-
-  fromPartial(object: DeepPartial<GetDaemonVersionResponse>): GetDaemonVersionResponse {
-    const message = createBaseGetDaemonVersionResponse();
-    message.version = object.version ?? "";
-    return message;
-  },
-};
-
 function createBaseGetWorkspaceAuthInfoRequest(): GetWorkspaceAuthInfoRequest {
   return { workspaceId: "" };
 }
@@ -1153,23 +1245,6 @@ export const LocalSSHServiceDefinition = {
       responseStream: false,
       options: {},
     },
-    ping: {
-      name: "Ping",
-      requestType: PingRequest,
-      requestStream: false,
-      responseType: PingResponse,
-      responseStream: false,
-      options: {},
-    },
-    /** GetDaemonVersion returns the version of the daemon */
-    getDaemonVersion: {
-      name: "GetDaemonVersion",
-      requestType: GetDaemonVersionRequest,
-      requestStream: false,
-      responseType: GetDaemonVersionResponse,
-      responseStream: false,
-      options: {},
-    },
   },
 } as const;
 
@@ -1178,12 +1253,6 @@ export interface LocalSSHServiceImplementation<CallContextExt = {}> {
   active(request: ActiveRequest, context: CallContext & CallContextExt): Promise<DeepPartial<ActiveResponse>>;
   /** Inactive is called when extension is deactivated */
   inactive(request: InactiveRequest, context: CallContext & CallContextExt): Promise<DeepPartial<InactiveResponse>>;
-  ping(request: PingRequest, context: CallContext & CallContextExt): Promise<DeepPartial<PingResponse>>;
-  /** GetDaemonVersion returns the version of the daemon */
-  getDaemonVersion(
-    request: GetDaemonVersionRequest,
-    context: CallContext & CallContextExt,
-  ): Promise<DeepPartial<GetDaemonVersionResponse>>;
 }
 
 export interface LocalSSHServiceClient<CallOptionsExt = {}> {
@@ -1191,12 +1260,6 @@ export interface LocalSSHServiceClient<CallOptionsExt = {}> {
   active(request: DeepPartial<ActiveRequest>, options?: CallOptions & CallOptionsExt): Promise<ActiveResponse>;
   /** Inactive is called when extension is deactivated */
   inactive(request: DeepPartial<InactiveRequest>, options?: CallOptions & CallOptionsExt): Promise<InactiveResponse>;
-  ping(request: DeepPartial<PingRequest>, options?: CallOptions & CallOptionsExt): Promise<PingResponse>;
-  /** GetDaemonVersion returns the version of the daemon */
-  getDaemonVersion(
-    request: DeepPartial<GetDaemonVersionRequest>,
-    options?: CallOptions & CallOptionsExt,
-  ): Promise<GetDaemonVersionResponse>;
 }
 
 export type ExtensionServiceDefinition = typeof ExtensionServiceDefinition;
@@ -1236,6 +1299,22 @@ export const ExtensionServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    getCurrentExtensionVersion: {
+      name: "GetCurrentExtensionVersion",
+      requestType: GetCurrentExtensionVersionRequest,
+      requestStream: false,
+      responseType: GetCurrentExtensionVersionResponse,
+      responseStream: false,
+      options: {},
+    },
+    tryRestartDaemon: {
+      name: "TryRestartDaemon",
+      requestType: TryRestartDaemonRequest,
+      requestStream: false,
+      responseType: TryRestartDaemonResponse,
+      responseStream: false,
+      options: {},
+    },
   },
 } as const;
 
@@ -1253,6 +1332,14 @@ export interface ExtensionServiceImplementation<CallContextExt = {}> {
     request: SendErrorReportRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<SendErrorReportResponse>>;
+  getCurrentExtensionVersion(
+    request: GetCurrentExtensionVersionRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<GetCurrentExtensionVersionResponse>>;
+  tryRestartDaemon(
+    request: TryRestartDaemonRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<TryRestartDaemonResponse>>;
 }
 
 export interface ExtensionServiceClient<CallOptionsExt = {}> {
@@ -1269,6 +1356,14 @@ export interface ExtensionServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<SendErrorReportRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<SendErrorReportResponse>;
+  getCurrentExtensionVersion(
+    request: DeepPartial<GetCurrentExtensionVersionRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<GetCurrentExtensionVersionResponse>;
+  tryRestartDaemon(
+    request: DeepPartial<TryRestartDaemonRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<TryRestartDaemonResponse>;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/src/proto/typescript/ipc/v1/ipc.ts
+++ b/src/proto/typescript/ipc/v1/ipc.ts
@@ -227,6 +227,13 @@ export interface PingRequest {
 export interface PingResponse {
 }
 
+export interface GetDaemonVersionRequest {
+}
+
+export interface GetDaemonVersionResponse {
+  version: string;
+}
+
 export interface GetWorkspaceAuthInfoRequest {
   workspaceId: string;
 }
@@ -1073,6 +1080,100 @@ export const PingResponse = {
   },
 };
 
+function createBaseGetDaemonVersionRequest(): GetDaemonVersionRequest {
+  return {};
+}
+
+export const GetDaemonVersionRequest = {
+  encode(_: GetDaemonVersionRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetDaemonVersionRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetDaemonVersionRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): GetDaemonVersionRequest {
+    return {};
+  },
+
+  toJSON(_: GetDaemonVersionRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<GetDaemonVersionRequest>): GetDaemonVersionRequest {
+    return GetDaemonVersionRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial(_: DeepPartial<GetDaemonVersionRequest>): GetDaemonVersionRequest {
+    const message = createBaseGetDaemonVersionRequest();
+    return message;
+  },
+};
+
+function createBaseGetDaemonVersionResponse(): GetDaemonVersionResponse {
+  return { version: "" };
+}
+
+export const GetDaemonVersionResponse = {
+  encode(message: GetDaemonVersionResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetDaemonVersionResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetDaemonVersionResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.version = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetDaemonVersionResponse {
+    return { version: isSet(object.version) ? String(object.version) : "" };
+  },
+
+  toJSON(message: GetDaemonVersionResponse): unknown {
+    const obj: any = {};
+    message.version !== undefined && (obj.version = message.version);
+    return obj;
+  },
+
+  create(base?: DeepPartial<GetDaemonVersionResponse>): GetDaemonVersionResponse {
+    return GetDaemonVersionResponse.fromPartial(base ?? {});
+  },
+
+  fromPartial(object: DeepPartial<GetDaemonVersionResponse>): GetDaemonVersionResponse {
+    const message = createBaseGetDaemonVersionResponse();
+    message.version = object.version ?? "";
+    return message;
+  },
+};
+
 function createBaseGetWorkspaceAuthInfoRequest(): GetWorkspaceAuthInfoRequest {
   return { workspaceId: "" };
 }
@@ -1245,6 +1346,23 @@ export const LocalSSHServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    ping: {
+      name: "Ping",
+      requestType: PingRequest,
+      requestStream: false,
+      responseType: PingResponse,
+      responseStream: false,
+      options: {},
+    },
+    /** GetDaemonVersion returns the version of the daemon */
+    getDaemonVersion: {
+      name: "GetDaemonVersion",
+      requestType: GetDaemonVersionRequest,
+      requestStream: false,
+      responseType: GetDaemonVersionResponse,
+      responseStream: false,
+      options: {},
+    },
   },
 } as const;
 
@@ -1253,6 +1371,12 @@ export interface LocalSSHServiceImplementation<CallContextExt = {}> {
   active(request: ActiveRequest, context: CallContext & CallContextExt): Promise<DeepPartial<ActiveResponse>>;
   /** Inactive is called when extension is deactivated */
   inactive(request: InactiveRequest, context: CallContext & CallContextExt): Promise<DeepPartial<InactiveResponse>>;
+  ping(request: PingRequest, context: CallContext & CallContextExt): Promise<DeepPartial<PingResponse>>;
+  /** GetDaemonVersion returns the version of the daemon */
+  getDaemonVersion(
+    request: GetDaemonVersionRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<GetDaemonVersionResponse>>;
 }
 
 export interface LocalSSHServiceClient<CallOptionsExt = {}> {
@@ -1260,6 +1384,12 @@ export interface LocalSSHServiceClient<CallOptionsExt = {}> {
   active(request: DeepPartial<ActiveRequest>, options?: CallOptions & CallOptionsExt): Promise<ActiveResponse>;
   /** Inactive is called when extension is deactivated */
   inactive(request: DeepPartial<InactiveRequest>, options?: CallOptions & CallOptionsExt): Promise<InactiveResponse>;
+  ping(request: DeepPartial<PingRequest>, options?: CallOptions & CallOptionsExt): Promise<PingResponse>;
+  /** GetDaemonVersion returns the version of the daemon */
+  getDaemonVersion(
+    request: DeepPartial<GetDaemonVersionRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<GetDaemonVersionResponse>;
 }
 
 export type ExtensionServiceDefinition = typeof ExtensionServiceDefinition;

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -40,7 +40,7 @@ import { IHostService } from './services/hostService';
 import { Configuration } from './configuration';
 import { getLocalSSHUrl, getServiceURL } from './common/utils';
 import { GitpodDefaultLocalhost as GITPOD_DEFAULT_LOCALHOST_RECORD, HOST_PUBLIC_KEY_TYPE, getHostKeyFingerprint, isDNSPointToLocalhost, isDomainConnectable } from './local-ssh/common';
-import { ensureDaemonStarted, tryStartDaemon } from './daemonStarter';
+import { ensureDaemonStarted } from './daemonStarter';
 
 interface LocalAppConfig {
 	gitpodHost: string;
@@ -563,7 +563,7 @@ export class RemoteConnector extends Disposable {
 	private tryEnsureLocalSSHDaemon() {
 		ensureDaemonStarted(this.logService, this.telemetryService, 3).then().catch(e => {
 			this.logService.debug('failed to start local SSH daemon: ' + e.toString());
-		})
+		});
 	}
 
 	private async getWorkspaceLocalAppSSHDestination(params: SSHConnectionParams): Promise<{ destination: SSHDestination; localAppSSHConfigPath: string }> {


### PR DESCRIPTION
- [ ] It should rebase after PR https://github.com/gitpod-io/gitpod-vscode-desktop/pull/50 merged

This PR changed 

#### 1️⃣  add restart logic in daemon
- If there's no connection to local-ssh
- Get extension version from extension ipc
- Compare with daemon running extension version
- If it's greater than current one, ask extension ipc to restart daemon later (trigger `onDidDaemonRestartRequired` event)
- Exit with proper exit code

#### 2️⃣  where we start daemon
 from
- Extension active
- Extension ipc service active and every time we are trying to ping local-ssh ipc

To 
- Extension active
- Extension ipc service received `onDidDaemonRestartRequired` event
- Trying to start a remote connection

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/IDE-54

## How to test
<!-- Provide steps to test this PR -->