### PR TITLE
Only show workspace stopping notification if window is correct remote window

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,7 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const remoteConnector = new RemoteConnector(context, sessionService, hostService, experiments, logger, telemetryService, notificationService);
 		context.subscriptions.push(remoteConnector);
 
-		const extensionIPCService = new ExtensionServiceServer(logger, sessionService, hostService, notificationService, telemetryService, experiments);
+		const extensionIPCService = new ExtensionServiceServer(context, logger, sessionService, hostService, notificationService, telemetryService, experiments);
 		context.subscriptions.push(extensionIPCService);
 
 		context.subscriptions.push(vscode.window.registerUriHandler({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Only show workspace stopping notification if window is correct remote window

This will fixes IDE-58

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open workspace in vscode desktop
2. stop workspace
3. try to reconnect 
4. the notification `workspace is not running, current phase ...` should always show in correct remote window.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
