### PR TITLE
Dynamic experiments host

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
 	},
 	"main": "./out/extension.js",
 	"segmentKey": "YErmvd89wPsrCuGcVnF2XAl846W9WIGl",
-	"configcatKey": "WBLaCPtkjkqKHlHedziE9g/LEAOCNkbuUKiqUZAcVg7dw",
+	"configcatKey": "gitpod",
 	"scripts": {
 		"vscode:prepublish": "webpack --mode production",
 		"webpack": "webpack --mode development",

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -23,11 +23,13 @@ export class ExperimentalSettings {
         key: string,
         extensionVersion: string,
         private readonly sessionService: ISessionService,
-        private readonly context: vscode.ExtensionContext,
         private readonly logger: ILogService
     ) {
+        const config = vscode.workspace.getConfiguration('gitpod');
+        const host = config.get<string>('host');
+
         this.configcatClient = configcat.createClientWithLazyLoad(key, {
-            baseUrl: new URL('/configcat', this.context.extensionMode === vscode.ExtensionMode.Production ? 'https://gitpod.io' : 'https://gitpod-staging.com').href,
+            baseUrl: new URL('/configcat', host).href,
             logger: {
                 debug(): void { },
                 log(): void { },

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -27,10 +27,7 @@ export class ExperimentalSettings {
         private readonly hostService: IHostService,
         private readonly logger: ILogService
     ) {
-        const host = hostService.gitpodHost;
-
-        this.configcatClient = configcat.createClientWithLazyLoad(key, {
-            baseUrl: new URL('/configcat', host).href,
+        const configCatOptions = {
             logger: {
                 debug(): void { },
                 log(): void { },
@@ -40,7 +37,20 @@ export class ExperimentalSettings {
             },
             requestTimeoutMs: 1500,
             cacheTimeToLiveSeconds: 60
+        };
+
+        this.configcatClient = configcat.createClientWithLazyLoad(key, {
+            baseUrl: new URL('/configcat', hostService.gitpodHost).href,
+            ...configCatOptions
         });
+
+        hostService.onDidChangeHost(() => {
+            this.configcatClient = configcat.createClientWithLazyLoad(key, {
+                baseUrl: new URL('/configcat', hostService.gitpodHost).href,
+                ...configCatOptions
+            });
+        });
+
         this.extensionVersion = new semver.SemVer(extensionVersion);
     }
 

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -9,7 +9,7 @@ import * as configcatcommon from 'configcat-common';
 import * as semver from 'semver';
 import { ISessionService } from './services/sessionService';
 import { ILogService } from './services/logService';
-import { Configuration } from './configuration';
+import { IHostService } from './services/hostService';
 
 const EXPERTIMENTAL_SETTINGS = [
     'gitpod.remote.useLocalApp',
@@ -24,9 +24,10 @@ export class ExperimentalSettings {
         key: string,
         extensionVersion: string,
         private readonly sessionService: ISessionService,
+        private readonly hostService: IHostService,
         private readonly logger: ILogService
     ) {
-        const host = Configuration.getGitpodHost();
+        const host = hostService.gitpodHost;
 
         this.configcatClient = configcat.createClientWithLazyLoad(key, {
             baseUrl: new URL('/configcat', host).href,

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -40,13 +40,13 @@ export class ExperimentalSettings {
         };
 
         this.configcatClient = configcat.createClientWithLazyLoad(key, {
-            baseUrl: new URL('/configcat', hostService.gitpodHost).href,
+            baseUrl: new URL('/configcat', this.hostService.gitpodHost).href,
             ...configCatOptions
         });
 
         hostService.onDidChangeHost(() => {
             this.configcatClient = configcat.createClientWithLazyLoad(key, {
-                baseUrl: new URL('/configcat', hostService.gitpodHost).href,
+                baseUrl: new URL('/configcat', this.hostService.gitpodHost).href,
                 ...configCatOptions
             });
         });

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -9,6 +9,7 @@ import * as configcatcommon from 'configcat-common';
 import * as semver from 'semver';
 import { ISessionService } from './services/sessionService';
 import { ILogService } from './services/logService';
+import { Configuration } from './configuration';
 
 const EXPERTIMENTAL_SETTINGS = [
     'gitpod.remote.useLocalApp',
@@ -25,8 +26,7 @@ export class ExperimentalSettings {
         private readonly sessionService: ISessionService,
         private readonly logger: ILogService
     ) {
-        const config = vscode.workspace.getConfiguration('gitpod');
-        const host = config.get<string>('host');
+        const host = Configuration.getGitpodHost();
 
         this.configcatClient = configcat.createClientWithLazyLoad(key, {
             baseUrl: new URL('/configcat', host).href,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const sessionService = new SessionService(hostService, logger);
 		context.subscriptions.push(sessionService);
 
-		const experiments = new ExperimentalSettings('gitpod', packageJSON.version, sessionService, logger);
+		const experiments = new ExperimentalSettings('gitpod', packageJSON.version, sessionService, hostService,logger);
 		context.subscriptions.push(experiments);
 
 		const settingsSync = new SettingsSync(commandManager, logger, telemetryService, notificationService);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const sessionService = new SessionService(hostService, logger);
 		context.subscriptions.push(sessionService);
 
-		const experiments = new ExperimentalSettings('gitpod', packageJSON.version, sessionService, context, logger);
+		const experiments = new ExperimentalSettings('gitpod', packageJSON.version, sessionService, logger);
 		context.subscriptions.push(experiments);
 
 		const settingsSync = new SettingsSync(commandManager, logger, telemetryService, notificationService);


### PR DESCRIPTION
Make the URL host of the experiments client configurable with the good ol' `gitpod.host`.

Fixes [IDE-75](https://linear.app/gitpod/issue/IDE-75/[code-desktop]-align-usage-of-configcat-for-dedicated)