### PR TITLE
Remove redundant `activationEvents`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,7 @@
 	},
 	"activationEvents": [
 		"onResolveRemoteAuthority:ssh-remote",
-		"onCommand:gitpod.syncProvider.add",
-		"onCommand:gitpod.syncProvider.remove",
-		"onCommand:gitpod.exportLogs",
 		"onCommand:gitpod.api.autoTunnel",
-		"onCommand:gitpod.installLocalExtensions",
-		"onAuthenticationRequest:gitpod",
 		"onUri",
 		"onStartupFinished"
 	],


### PR DESCRIPTION
Fix this warning:
```
This activation event can be removed for extensions targeting engine version ^1.75 as VS Code will generate these automatically from your package.json contribution declarations.
```

The message comes from [here](https://github.com/microsoft/vscode/blob/b7c81ac7ccf1f94766a1bf1d1e0e4b4cfac5db66/extensions/extension-editing/src/extensionLinter.ts#L38)