### PR TITLE
Allow user to force disable local ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
 						"type": "number",
 						"description": "The port to use for the local SSH ipc server.",
 						"scope": "application"
+					},
+					"gitpod.remote.disableLocalSSH": {
+						"type": "boolean",
+						"description": "Use other ways (except local SSH proxy) to connect to a remote workspace.\nWarning: It's a temporary solution when you can't connect by default settings, and may be removed in the near future.",
+						"default": false,
+						"scope": "application"
 					}
 				}
 			},

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,10 @@ function getUseLocalApp() {
     return vscode.workspace.getConfiguration('gitpod').get<boolean>('remote.useLocalApp', false);
 }
 
+function disableLocalSSH() {
+    return vscode.workspace.getConfiguration('gitpod').get<boolean>('remote.disableLocalSSH', false);
+}
+
 function getLocalSshExtensionIpcPort() {
     let defaultPort = 43025;
     if (vscode.env.appName.includes('Insiders')) {
@@ -28,5 +32,6 @@ function getLocalSshExtensionIpcPort() {
 export const Configuration = {
     getGitpodHost,
     getUseLocalApp,
+    disableLocalSSH,
     getLocalSshExtensionIpcPort,
 };

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -697,11 +697,11 @@ export class RemoteConnector extends Disposable {
 				const userOverrideConfig = {
 					useLocalApp: {
 						override: userOverride,
-						value: forceUseLocalApp,
+						value: String(forceUseLocalApp),
 					},
 					disableLocalSSH: {
 						override: String(isUserOverrideSetting('gitpod.remote.disableLocalSSH')),
-						value: forceDisableLocalSSH
+						value: String(forceDisableLocalSSH)
 					},
 				};
 				let sshDestination: SSHDestination | undefined;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Connect to a workspace, it should use local-ssh
- Add `gitpod.remote.disableLocalSSH: true` to setting json, it should not use local-ssh

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
