### PR TITLE
use http create key endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
 						"type": "string",
 						"description": "The log level for ssh proxy.",
 						"scope": "application",
-						"enum": ["none", "debug"],
+						"enum": [
+							"none",
+							"debug"
+						],
 						"default": "none"
 					}
 				}
@@ -429,13 +432,12 @@
 		"webpack-cli": "^4.7.2"
 	},
 	"dependencies": {
-		"@connectrpc/connect-node": "1.1.2",
 		"@connectrpc/connect": "1.1.2",
+		"@connectrpc/connect-node": "1.1.2",
 		"@gitpod/gitpod-protocol": "main-gha",
 		"@gitpod/local-app-api-grpcweb": "main-gha",
 		"@gitpod/public-api": "main-gha",
 		"@gitpod/supervisor-api-grpcweb": "main-gha",
-		"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
 		"@microsoft/dev-tunnels-ssh": "^3.11.24",
 		"@microsoft/dev-tunnels-ssh-keys": "^3.11.24",
 		"@microsoft/dev-tunnels-ssh-tcp": "^3.11.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,11 +203,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@improbable-eng/grpc-web-node-http-transport@^0.14.0":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.14.1.tgz#16c078db2e10aca9a8f7fb235a80b2fa447273a3"
-  integrity sha512-ZsCTzI1iKUbmQjB5DNZSI5/hvdliuaPpS2h8mVj1QzynL3IFb5NrNnHVHbfcH1wbm26Ka6Z1CrKFGvKLrmbFIg==
-
 "@improbable-eng/grpc-web@0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@improbable-eng/grpc-web/-/grpc-web-0.14.0.tgz#a71c5af471dcef6a2810798f71f93ed8d6ac3817"


### PR DESCRIPTION
Switch to use http endpoint for create private key pair

This endpoint introduced in https://github.com/gitpod-io/gitpod/pull/18411 which is 4 month ago, gitpod cloud and dedicated user already have this endpoint

To use this endpoint, we can be more smoothly compatible with next-gen. 