### PR TITLE
Fix local-ssh not work in vscode insider

### DIFF
--- a/src/local-ssh/proxy.ts
+++ b/src/local-ssh/proxy.ts
@@ -20,7 +20,7 @@ interface ClientOptions {
 }
 
 function getClientOptions(): ClientOptions {
-    const args = process.argv.slice(2);
+    const args = process.argv.slice(2).filter(arg => arg != "--ms-enable-electron-run-as-node");
     // %h is in the form of <ws_id>.vss.<gitpod_host>'
     // add `https://` prefix since our gitpodHost is actually a url not host
     const host = args[0];

--- a/src/local-ssh/proxy.ts
+++ b/src/local-ssh/proxy.ts
@@ -20,7 +20,9 @@ interface ClientOptions {
 }
 
 function getClientOptions(): ClientOptions {
-    const args = process.argv.slice(2).filter(arg => arg != "--ms-enable-electron-run-as-node");
+    // Since 1.87.0 new electron version does not use this falga anymore, for now filter it
+    // we we should delete the logic and update minimun vscode version of extension
+    const args = process.argv.slice(2).filter(arg => arg !== '--ms-enable-electron-run-as-node');
     // %h is in the form of <ws_id>.vss.<gitpod_host>'
     // add `https://` prefix since our gitpodHost is actually a url not host
     const host = args[0];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
electron seems remove support for `--ms-enable-electron-run-as-node` flags in `vscode insider` It will cause electron not to swallow this flags, resulting in a change in our parameter position.

<img width="1129" alt="image" src="https://github.com/gitpod-io/gitpod-vscode-desktop/assets/20944364/94074191-818d-4e04-bf64-7e16b560c520">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. build a extension using this branch and install it in both `vscode insider` and `vscode stable`, and restart vscode
2. try to open workspace via `vscode insider` and `vscode stable`
3. check remote hostname, it should be `*.vsi.*` or `*.vss.*`


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
