### PR TITLE
Always update remotePlatform for gitpodHost's wildcard

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		const hostService = new HostService(context, notificationService, logger);
 		context.subscriptions.push(hostService);
-		await hostService.updateSSHRemotePlatform();
 
 		const sessionService = new SessionService(hostService, logger);
 		context.subscriptions.push(sessionService);
@@ -129,6 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		// Because auth provider implementation is in the same extension, we need to wait for it to activate first
 		sessionService.didFirstLoad.then(async () => {
+			await remoteConnector.updateSSHRemotePlatform();
 			if (remoteConnectionInfo) {
 				remoteSession = new RemoteSession(remoteConnectionInfo.connectionInfo, context, remoteService, hostService, sessionService, experiments, logger!, telemetryService!, notificationService);
 				await remoteSession.initialize();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		const hostService = new HostService(context, notificationService, logger);
 		context.subscriptions.push(hostService);
+		await hostService.updateSSHRemotePlatform();
 
 		const sessionService = new SessionService(hostService, logger);
 		context.subscriptions.push(sessionService);

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -384,15 +384,14 @@ export class RemoteConnector extends Disposable {
 	// Force Linux as host platform (https://github.com/gitpod-io/gitpod/issues/16058)
 	public async updateSSHRemotePlatform() {
 		try {
-			
-			const hostname = '*.' + (new URL(this.hostService.gitpodHost)).hostname;
 			const existingSSHHostPlatforms = vscode.workspace.getConfiguration('remote.SSH').get<{ [host: string]: string }>('remotePlatform', {});
+			const hostname = '*.' + (new URL(this.hostService.gitpodHost)).hostname;
 			const targetPlatform = 'linux';
 			if (!existingSSHHostPlatforms[hostname] || existingSSHHostPlatforms[hostname] !== targetPlatform) {
 				await vscode.workspace.getConfiguration('remote.SSH').update('remotePlatform', { ...existingSSHHostPlatforms, [hostname]: targetPlatform }, vscode.ConfigurationTarget.Global);
 			}
-		} catch (error) {
-			this.logService.error('Error updating remotePlatform configuration', error);
+		} catch (e) {
+			this.logService.error('Error updating remotePlatform configuration', e);
 		}
 	}
 }

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -21,7 +21,6 @@ import { INotificationService } from './services/notificationService';
 import { SSHKey } from '@gitpod/public-api/lib/gitpod/experimental/v1/user_pb';
 import { getAgentSock, SSHError, testSSHConnection as testSSHGatewayConnection } from './sshTestConnection';
 import { gatherIdentityFiles } from './ssh/identityFiles';
-import { isWindows } from './common/platform';
 import SSHDestination from './ssh/sshDestination';
 import { NoRunningInstanceError, NoSSHGatewayError, SSHConnectionParams, SSH_DEST_KEY, getLocalSSHDomain } from './remote';
 import { ISessionService } from './services/sessionService';
@@ -360,14 +359,6 @@ export class RemoteConnector extends Disposable {
 				await this.remoteService.updateRemoteSSHConfig();
 
 				await this.context.globalState.update(`${SSH_DEST_KEY}${sshDestination!.toRemoteSSHString()}`, { ...params } as SSHConnectionParams);
-
-				// Force Linux as host platform (https://github.com/gitpod-io/gitpod/issues/16058)
-				if (isWindows) {
-					const existingSSHHostPlatforms = vscode.workspace.getConfiguration('remote.SSH').get<{ [host: string]: string }>('remotePlatform', {});
-					if (!existingSSHHostPlatforms[sshDestination!.hostname]) {
-						await vscode.workspace.getConfiguration('remote.SSH').update('remotePlatform', { ...existingSSHHostPlatforms, [sshDestination!.hostname]: 'linux' }, vscode.ConfigurationTarget.Global);
-					}
-				}
 
 				return sshDestination;
 			}

--- a/src/services/hostService.ts
+++ b/src/services/hostService.ts
@@ -17,7 +17,6 @@ export interface IHostService {
     onDidChangeHost: vscode.Event<void>;
 
     changeHost(newHost: string, force?: boolean): Promise<boolean>;
-    updateSSHRemotePlatform(): Promise<void>;
 }
 
 export class HostService extends Disposable implements IHostService {
@@ -52,7 +51,6 @@ export class HostService extends Disposable implements IHostService {
                 if (new URL(this._gitpodHost).host !== new URL(newGitpodHost).host) {
                     this._gitpodHost = newGitpodHost;
                     this._onDidChangeHost.fire();
-                    this.updateSSHRemotePlatform().then(() => {});
                 }
             }
         }));
@@ -79,19 +77,5 @@ export class HostService extends Disposable implements IHostService {
             this.logService.info(`Updated 'gitpod.host' setting to '${newHost}'`);
         }
         return true;
-    }
-
-    // Force Linux as host platform (https://github.com/gitpod-io/gitpod/issues/16058)
-    async updateSSHRemotePlatform() {
-        try {
-            const hostname = '*.' + (new URL(this.gitpodHost)).hostname;
-            const existingSSHHostPlatforms = vscode.workspace.getConfiguration('remote.SSH').get<{ [host: string]: string }>('remotePlatform', {});
-            const targetPlatform = 'linux';
-            if (!existingSSHHostPlatforms[hostname] || existingSSHHostPlatforms[hostname] !== targetPlatform) {
-                await vscode.workspace.getConfiguration('remote.SSH').update('remotePlatform', { ...existingSSHHostPlatforms, [hostname]: targetPlatform }, vscode.ConfigurationTarget.Global);
-            }
-        } catch (error) {
-            this.logService.error('Error updating remotePlatform configuration', error);
-        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [ENT-181](https://linear.app/gitpod/issue/ENT-181)

## How to test
<!-- Provide steps to test this PR -->
- Build and use extension
- It should update settings remotePlatform to `linux` when connecting to a workspace in Gitpod
- It should be able to connect to workspaces

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
