### PR TITLE
Disable contributions when in gp next remote window

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,16 +270,20 @@
 			],
 			"commandPalette": [
 				{
-					"command": "gitpod.workspaces.refresh",
-					"when": "false"
+					"command": "gitpod.signIn",
+					"when": "!gitpod.inGpNextRemoteWindow"
+				},
+				{
+					"command": "gitpod.exportLogs",
+					"when": "!gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"command": "gitpod.workspaces.refresh",
-					"when": "gitpod.authenticated == true"
+					"when": "gitpod.authenticated == true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"command": "gitpod.workspaces.connectInNewWindow",
-					"when": "gitpod.authenticated == true"
+					"when": "gitpod.authenticated == true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"command": "gitpod.workspaces.connectInNewWindow_context",
@@ -287,7 +291,7 @@
 				},
 				{
 					"command": "gitpod.workspaces.connectInCurrentWindow",
-					"when": "gitpod.authenticated == true"
+					"when": "gitpod.authenticated == true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"command": "gitpod.workspaces.connectInCurrentWindow_context",
@@ -307,7 +311,7 @@
 				},
 				{
 					"command": "gitpod.workspaces.stopWorkspace",
-					"when": "gitpod.authenticated == true && gitpod.inWorkspace != true"
+					"when": "gitpod.authenticated == true && gitpod.inWorkspace != true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"command": "gitpod.workspaces.stopWorkspace_context",
@@ -335,7 +339,7 @@
 				},
 				{
 					"command": "gitpod.workspaces.deleteWorkspace",
-					"when": "gitpod.authenticated == true && gitpod.inWorkspace != true"
+					"when": "gitpod.authenticated == true && gitpod.inWorkspace != true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"command": "gitpod.workspaces.deleteWorkspace_context",
@@ -362,13 +366,13 @@
 					"id": "gitpod-login",
 					"name": "Login",
 					"icon": "$(squirrel)",
-					"when": "gitpod.authenticated != true"
+					"when": "gitpod.authenticated != true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"id": "gitpod-workspaces",
 					"name": "Workspaces",
 					"icon": "$(squirrel)",
-					"when": "gitpod.authenticated == true"
+					"when": "gitpod.authenticated == true && !gitpod.inGpNextRemoteWindow"
 				},
 				{
 					"id": "gitpod-workspace",
@@ -381,7 +385,7 @@
 		"viewsWelcome": [
 			{
 				"view": "gitpod-login",
-				"when": "gitpod.authenticated != true",
+				"when": "gitpod.authenticated != true && !gitpod.inGpNextRemoteWindow",
 				"contents": "You have not yet signed in with Gitpod\n[Sign in](command:gitpod.signIn)"
 			}
 		]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ import { NotificationService } from './services/notificationService';
 import { RemoteConnector } from './remoteConnector';
 import { TelemetryService } from './services/telemetryService';
 import { RemoteSession } from './remoteSession';
-import { SSHConnectionParams, getGitpodRemoteWindowConnectionInfo } from './remote';
+import { SSHConnectionParams, getGitpodRemoteWindowConnectionInfo, isGitpodNextRemoteWindow } from './remote';
 import { HostService } from './services/hostService';
 import { SessionService } from './services/sessionService';
 import { CommandManager } from './commandManager';
@@ -44,6 +44,11 @@ let logger: vscode.LogOutputChannel | undefined;
 export async function activate(context: vscode.ExtensionContext) {
 	const extensionId = context.extension.id;
 	const packageJSON = context.extension.packageJSON;
+
+	if (isGitpodNextRemoteWindow()) {
+		vscode.commands.executeCommand('setContext', 'gitpod.inGpNextRemoteWindow', true);
+		return;
+	}
 
 	let remoteConnectionInfo: { connectionInfo: SSHConnectionParams; remoteUri: vscode.Uri; sshDestStr: string } | undefined;
 	let success = false;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Disable contributions when in gp next remote window

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/NEXT-746

## How to test
<!-- Provide steps to test this PR -->
- Have both gp enterprise and next extensions
- Connect to next environment
- Check gp enterprise extension contributions are not shown in UI

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
