### PR TITLE
Use modal dialog when in gitpod flex env

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Gitpod",
 	"description": "Gitpod Support",
 	"publisher": "gitpod",
-	"version": "0.0.175",
+	"version": "0.0.176",
 	"license": "MIT",
 	"icon": "resources/gitpod.png",
 	"repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				try {
 					const params: SSHConnectionParams = JSON.parse(uri.query);
 					const openNewWindow = 'Use New Window';
-					vscode.window.showInformationMessage(`We cannot open Gitpod workspace on ${params.gitpodHost} from a Gitpod Flex environment window.`, openNewWindow)
+					vscode.window.showWarningMessage(`We cannot open Gitpod workspace on ${params.gitpodHost} from a Gitpod Flex environment window.`, { modal: true }, openNewWindow)
 						.then(action => {
 							if (action === openNewWindow) {
 								vscode.commands.executeCommand('vscode.newWindow', { remoteAuthority: null });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use modal dialog when in gitpod flex env

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/NEXT-1595/cannot-open-gitpod-workspace-from-flex-environment-window

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
