### PR TITLE
Dev Container heartbeats

### DIFF
--- a/src/commands/workspaces.ts
+++ b/src/commands/workspaces.ts
@@ -361,7 +361,7 @@ export class ConnectInCurrentWindowCommand implements Command {
 
 	private async initializeLocalSSH(workspaceId: string) {
 		try {
-			await this.remoteService.updateRemoteSSHConfig();
+			await this.remoteService.updateRemoteConfig();
 			await Promise.all([
 				this.remoteService.setupSSHProxy(),
 				this.remoteService.startLocalSSHServiceServer()

--- a/src/remoteConnector.ts
+++ b/src/remoteConnector.ts
@@ -265,7 +265,7 @@ export class RemoteConnector extends Disposable {
 				try {
 					this.telemetryService.sendUserFlowStatus('connecting', localSSHFlow);
 					// If needed, revert local-app changes first
-					await this.remoteService.updateRemoteSSHConfig();
+					await this.remoteService.updateRemoteConfig();
 
 					this.remoteService.flow = sshFlow;
 					await Promise.all([
@@ -344,7 +344,7 @@ export class RemoteConnector extends Disposable {
 					}
 				}
 
-				await this.remoteService.updateRemoteSSHConfig();
+				await this.remoteService.updateRemoteConfig();
 
 				await this.context.globalState.update(`${SSH_DEST_KEY}${sshDestination!.toRemoteSSHString()}`, { ...params } as SSHConnectionParams);
 

--- a/src/services/remoteService.ts
+++ b/src/services/remoteService.ts
@@ -347,14 +347,11 @@ export class RemoteService extends Disposable implements IRemoteService {
             vscode.workspace.getConfiguration('dev.containers');
         const defaultDevContainerExtConfigInfo = remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
         const defaultDevContainerExtensions = defaultDevContainerExtConfigInfo?.globalValue ?? [];
-        const defaultDCExtConfigInfo =
-            remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
-        const defaultDcExtensions = defaultDCExtConfigInfo?.globalValue ?? [];
         if (!defaultDevContainerExtensions.includes('gitpod.gitpod-remote-ssh')) {
             defaultDevContainerExtensions.unshift('gitpod.gitpod-remote-ssh');
             await remoteDevContainerConfig.update(
                 'defaultExtensions',
-                defaultDcExtensions,
+                defaultDevContainerExtensions,
                 vscode.ConfigurationTarget.Global,
             );
         }
@@ -407,7 +404,7 @@ export class RemoteService extends Disposable implements IRemoteService {
         } catch (error) {
             const msg = `Error while installing local extensions on remote.`;
             this.logService.error(msg);
-            this.logService.trace(error)
+            this.logService.trace(error);
 
             const status = 'failed';
             const seeLogs = 'See Logs';

--- a/src/services/remoteService.ts
+++ b/src/services/remoteService.ts
@@ -331,25 +331,27 @@ export class RemoteService extends Disposable implements IRemoteService {
 
     async updateRemoteConfig() {
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
-        const defaultExtConfigInfo =
+        const defaultSSHExtConfigInfo =
             remoteSSHconfig.inspect<string[]>('defaultExtensions');
-        const defaultExtensions = defaultExtConfigInfo?.globalValue ?? [];
-        if (!defaultExtensions.includes('gitpod.gitpod-remote-ssh')) {
-            defaultExtensions.unshift('gitpod.gitpod-remote-ssh');
+        const defaultSSHExtensions = defaultSSHExtConfigInfo?.globalValue ?? [];
+        if (!defaultSSHExtensions.includes('gitpod.gitpod-remote-ssh')) {
+            defaultSSHExtensions.unshift('gitpod.gitpod-remote-ssh');
             await remoteSSHconfig.update(
                 'defaultExtensions',
-                defaultExtensions,
+                defaultSSHExtensions,
                 vscode.ConfigurationTarget.Global,
             );
         }
 
         const remoteDevContainerConfig =
             vscode.workspace.getConfiguration('dev.containers');
+        const defaultDevContainerExtConfigInfo = remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
+        const defaultDevContainerExtensions = defaultDevContainerExtConfigInfo?.globalValue ?? [];
         const defaultDCExtConfigInfo =
             remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
         const defaultDcExtensions = defaultDCExtConfigInfo?.globalValue ?? [];
-        if (!defaultExtensions.includes('gitpod.gitpod-remote-ssh')) {
-            defaultExtensions.unshift('gitpod.gitpod-remote-ssh');
+        if (!defaultDevContainerExtensions.includes('gitpod.gitpod-remote-ssh')) {
+            defaultDevContainerExtensions.unshift('gitpod.gitpod-remote-ssh');
             await remoteDevContainerConfig.update(
                 'defaultExtensions',
                 defaultDcExtensions,
@@ -406,7 +408,7 @@ export class RemoteService extends Disposable implements IRemoteService {
             const msg = `Error while installing local extensions on remote.`;
             this.logService.error(msg);
             this.logService.trace(error)
-            
+
             const status = 'failed';
             const seeLogs = 'See Logs';
             const action = await this.notificationService.showErrorMessage(msg, { flow: flowData, id: status }, seeLogs);

--- a/src/services/remoteService.ts
+++ b/src/services/remoteService.ts
@@ -329,19 +329,42 @@ export class RemoteService extends Disposable implements IRemoteService {
         throw new Error('SSH password modal dialog, Canceled');
     }
 
-    async updateRemoteSSHConfig() {
-		const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
-		const defaultExtConfigInfo = remoteSSHconfig.inspect<string[]>('defaultExtensions');
-		const defaultExtensions = defaultExtConfigInfo?.globalValue ?? [];
-		if (!defaultExtensions.includes('gitpod.gitpod-remote-ssh')) {
-			defaultExtensions.unshift('gitpod.gitpod-remote-ssh');
-			await remoteSSHconfig.update('defaultExtensions', defaultExtensions, vscode.ConfigurationTarget.Global);
-		}
+    async updateRemoteConfig() {
+        const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
+        const defaultExtConfigInfo =
+            remoteSSHconfig.inspect<string[]>('defaultExtensions');
+        const defaultExtensions = defaultExtConfigInfo?.globalValue ?? [];
+        if (!defaultExtensions.includes('gitpod.gitpod-remote-ssh')) {
+            defaultExtensions.unshift('gitpod.gitpod-remote-ssh');
+            await remoteSSHconfig.update(
+                'defaultExtensions',
+                defaultExtensions,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
 
-		const currentConfigFile = remoteSSHconfig.get<string>('configFile');
-		if (currentConfigFile?.includes('gitpod_ssh_config')) {
-			await remoteSSHconfig.update('configFile', undefined, vscode.ConfigurationTarget.Global);
-		}
+        const remoteDevContainerConfig =
+            vscode.workspace.getConfiguration('dev.containers');
+        const defaultDCExtConfigInfo =
+            remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
+        const defaultDcExtensions = defaultDCExtConfigInfo?.globalValue ?? [];
+        if (!defaultExtensions.includes('gitpod.gitpod-remote-ssh')) {
+            defaultExtensions.unshift('gitpod.gitpod-remote-ssh');
+            await remoteDevContainerConfig.update(
+                'defaultExtensions',
+                defaultDcExtensions,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
+
+        const currentConfigFile = remoteSSHconfig.get<string>('configFile');
+        if (currentConfigFile?.includes('gitpod_ssh_config')) {
+            await remoteSSHconfig.update(
+                'configFile',
+                undefined,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
     }
 
     async initializeRemoteExtensions() {

--- a/src/services/remoteService.ts
+++ b/src/services/remoteService.ts
@@ -43,7 +43,7 @@ export interface IRemoteService {
     getWorkspaceSSHDestination(wsData: WorkspaceData): Promise<{ destination: SSHDestination; password?: string }>;
     showSSHPasswordModal(wsData: WorkspaceData, password: string): Promise<void>;
 
-    updateRemoteSSHConfig(): Promise<void>;
+    updateRemoteConfig(): Promise<void>;
     initializeRemoteExtensions(): Promise<void>;
 }
 
@@ -402,10 +402,11 @@ export class RemoteService extends Disposable implements IRemoteService {
                 throw e;
             }
             this.telemetryService.sendUserFlowStatus('synced', flowData);
-        } catch {
+        } catch (error) {
             const msg = `Error while installing local extensions on remote.`;
             this.logService.error(msg);
-
+            this.logService.trace(error)
+            
             const status = 'failed';
             const seeLogs = 'See Logs';
             const action = await this.notificationService.showErrorMessage(msg, { flow: flowData, id: status }, seeLogs);


### PR DESCRIPTION
## Description

If a user happens to use the "Reopen in container" feature of VS Code Desktop, we should still be able to send heartbeats and not let workspaces time out.

## How to test
<!-- Provide steps to test this PR -->

1. Build the extension using `yarn package`
2. Install it 
3. Open a workspace from https://github.com/filiptronicek/vscode-remote-try-go/tree/ft/ak/magic in `catfood`
4. Use "Reopen in Container" when VS Code Desktop asks you
5. Check the Gitpod output to see we're sending heartbeats every now and then