### PR TITLE
Only write dev.containers.defaultExtensions setting if devcontainers extension is installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Gitpod",
 	"description": "Gitpod Support",
 	"publisher": "gitpod",
-	"version": "0.0.178",
+	"version": "0.0.179",
 	"license": "MIT",
 	"icon": "resources/gitpod.png",
 	"repository": {

--- a/src/services/remoteService.ts
+++ b/src/services/remoteService.ts
@@ -331,8 +331,7 @@ export class RemoteService extends Disposable implements IRemoteService {
 
     async updateRemoteConfig() {
         const remoteSSHconfig = vscode.workspace.getConfiguration('remote.SSH');
-        const defaultSSHExtConfigInfo =
-            remoteSSHconfig.inspect<string[]>('defaultExtensions');
+        const defaultSSHExtConfigInfo = remoteSSHconfig.inspect<string[]>('defaultExtensions');
         const defaultSSHExtensions = defaultSSHExtConfigInfo?.globalValue ?? [];
         if (!defaultSSHExtensions.includes('gitpod.gitpod-remote-ssh')) {
             defaultSSHExtensions.unshift('gitpod.gitpod-remote-ssh');
@@ -343,17 +342,19 @@ export class RemoteService extends Disposable implements IRemoteService {
             );
         }
 
-        const remoteDevContainerConfig =
-            vscode.workspace.getConfiguration('dev.containers');
-        const defaultDevContainerExtConfigInfo = remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
-        const defaultDevContainerExtensions = defaultDevContainerExtConfigInfo?.globalValue ?? [];
-        if (!defaultDevContainerExtensions.includes('gitpod.gitpod-remote-ssh')) {
-            defaultDevContainerExtensions.unshift('gitpod.gitpod-remote-ssh');
-            await remoteDevContainerConfig.update(
-                'defaultExtensions',
-                defaultDevContainerExtensions,
-                vscode.ConfigurationTarget.Global,
-            );
+        const msVscodeRemoteContainersExt = vscode.extensions.getExtension('ms-vscode-remote.remote-containers');
+        if (msVscodeRemoteContainersExt) {
+            const remoteDevContainerConfig = vscode.workspace.getConfiguration('dev.containers');
+            const defaultDevContainerExtConfigInfo = remoteDevContainerConfig.inspect<string[]>('defaultExtensions');
+            const defaultDevContainerExtensions = defaultDevContainerExtConfigInfo?.globalValue ?? [];
+            if (!defaultDevContainerExtensions.includes('gitpod.gitpod-remote-ssh')) {
+                defaultDevContainerExtensions.unshift('gitpod.gitpod-remote-ssh');
+                await remoteDevContainerConfig.update(
+                    'defaultExtensions',
+                    defaultDevContainerExtensions,
+                    vscode.ConfigurationTarget.Global,
+                );
+            }
         }
 
         const currentConfigFile = remoteSSHconfig.get<string>('configFile');


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Only write dev.containers.defaultExtensions setting if devcontainers extension is installed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
