### PR TITLE
Add view with Gitpod Flex instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,8 +382,9 @@
 				},
 				{
 					"id": "gitpod-flex-help",
-					"name": "Help",
-					"icon": "$(squirrel)"
+					"name": "Looking for Gitpod Flex?",
+					"icon": "$(squirrel)",
+					"when": "gitpod.host === 'https://gitpod.io'"
 				}
 			]
 		},
@@ -395,7 +396,7 @@
 			},
 			{
 				"view": "gitpod-flex-help",
-				"contents": "Connecting to Gitpod Flex environments requires installing the [Gitpod Flex extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-flex) and opening them through the [Gitpod Flex](https://app.gitpod.io/). This view is only to manage [Gitpod Classic](https://gitpod.io/workspaces) workspaces."
+				"contents": "Connecting to Gitpod Flex environments requires installing the [Gitpod Flex extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-flex) and opening them through the [Gitpod Flex](https://app.gitpod.io/).\nThis view is only to manage [Gitpod Classic](https://gitpod.io/workspaces) workspaces."
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Gitpod",
 	"description": "Required to connect to Classic workspaces",
 	"publisher": "gitpod",
-	"version": "0.0.180",
+	"version": "0.0.181",
 	"license": "MIT",
 	"icon": "resources/gitpod.png",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -379,6 +379,11 @@
 					"name": "Workspace",
 					"icon": "$(squirrel)",
 					"when": "false"
+				},
+				{
+					"id": "gitpod-flex-help",
+					"name": "Help",
+					"icon": "$(squirrel)"
 				}
 			]
 		},
@@ -387,6 +392,10 @@
 				"view": "gitpod-login",
 				"when": "gitpod.authenticated != true && !gitpod.inGitpodFlexRemoteWindow",
 				"contents": "You have not yet signed in with Gitpod\n[Sign in](command:gitpod.signIn)"
+			},
+			{
+				"view": "gitpod-flex-help",
+				"contents": "Connecting to Gitpod Flex environments requires installing the [Gitpod Flex extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-flex) and opening them through the [Gitpod Flex](https://app.gitpod.io/). This view is only to manage [Gitpod Classic](https://gitpod.io/workspaces) workspaces."
 			}
 		]
 	},

--- a/src/services/hostService.ts
+++ b/src/services/hostService.ts
@@ -38,6 +38,7 @@ export class HostService extends Disposable implements IHostService {
         super();
 
         this._gitpodHost = Configuration.getGitpodHost();
+        this.updateGitpodHostContextKey();
 
         this._register(vscode.workspace.onDidChangeConfiguration(e => {
             if (e.affectsConfiguration('gitpod.host')) {
@@ -50,10 +51,20 @@ export class HostService extends Disposable implements IHostService {
                 const newGitpodHost = Configuration.getGitpodHost();
                 if (new URL(this._gitpodHost).host !== new URL(newGitpodHost).host) {
                     this._gitpodHost = newGitpodHost;
+                    this.updateGitpodHostContextKey();
                     this._onDidChangeHost.fire();
                 }
             }
         }));
+    }
+
+    private updateGitpodHostContextKey() {
+        try {
+            const origin = new URL(this.gitpodHost).origin;
+            vscode.commands.executeCommand('setContext', 'gitpod.host', origin);
+        } catch (e) {
+            vscode.commands.executeCommand('setContext', 'gitpod.host', undefined);
+        }
     }
 
     async changeHost(newHost: string, skipRemoteWindowCheck: boolean = false) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add view with Gitpod Flex instructions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/NEXT-2305/[vscode]-add-new-webview-in-classic-with-gitpod-flex-instructions

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold

<img width="302" alt="image" src="https://github.com/user-attachments/assets/52ce6108-14f0-4fd0-b657-442ef86badec">

