### PR TITLE
[signing] Sigin: Offer manual fallback in case the extension can't open a browser

### DIFF
--- a/src/authentication/gitpodServer.ts
+++ b/src/authentication/gitpodServer.ts
@@ -29,8 +29,8 @@ async function getUserInfo(token: string, serviceUrl: string, logger: ILogServic
 	};
 }
 
-const ACTION_COPY = "Copy to clipboard";
-const ACTION_CANCEL = "Cancel";
+const ACTION_COPY = 'Copy to clipboard';
+const ACTION_CANCEL = 'Cancel';
 
 export default class GitpodServer extends Disposable {
 
@@ -82,11 +82,11 @@ export default class GitpodServer extends Disposable {
 			const success = await vscode.env.openExternal(uri as any);
 			if (!success) {
 				// Handle the case where the extension can't open a browser window
-				const action = await vscode.window.showWarningMessage("There was a problem opening the login URL in your browser. Please copy it into your browser manually.", ACTION_COPY, ACTION_CANCEL);
+				const action = await vscode.window.showWarningMessage('There was a problem opening the login URL in your browser. Please copy it into your browser manually.', ACTION_COPY, ACTION_CANCEL);
 				if (action === ACTION_COPY) {
 					await vscode.env.clipboard.writeText(uri);
 				} else if (action === ACTION_CANCEL) {
-					throw new Error("Signin cancelled by user");
+					throw new Error('Signin cancelled by user');
 				}
 			}
 


### PR DESCRIPTION
## Description
Addresses an issue I see when trying to signin with cursor (appimage, on Linux):
 1. Stays in "Signing in" for 60s and then fails 
    - ![image](https://github.com/user-attachments/assets/47c3bc78-e128-448f-97ca-89756867a3ce)
 2. Logs read:
```
2025-01-28 17:36:24.236 [info] Logging in for the following scopes: function:deleteWorkspace function:getLoggedInUser function:getOwnerToken function:getSSHPublicKeys function:getWorkspace function:getWorkspaces function:sendHeartBeat function:startWorkspace function:stopWorkspace resource:default
2025-01-28 17:37:31.686 [error] Failed to load session: Cancelled
2025-01-28 17:37:31.686 [error] Failed to sign in
```

The idea here is to show a warning if `openExternal` returns `false` (hope that is the right signal).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

No clue. @filiptronicek any idea how to test this?

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
