### PR TITLE
Don't use binary format for transport in public api client

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Gitpod",
 	"description": "Required to connect to Classic workspaces",
 	"publisher": "gitpod",
-	"version": "0.0.181",
+	"version": "0.0.182",
 	"license": "MIT",
 	"icon": "resources/gitpod.png",
 	"repository": {

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -84,7 +84,7 @@ export class GitpodPublicApi extends Disposable implements IGitpodAPI {
             baseUrl: serviceUrl.toString(),
             httpVersion: '2',
             interceptors: [authInterceptor, metricsInterceptor],
-            useBinaryFormat: true,
+            useBinaryFormat: false,
             pingIntervalMs: 120000,
             pingTimeoutMs: 10000
         });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Don't use binary format, binary format forces http2, it's preferable to downgrade to http1.1 if http2 is not available for some reason 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
